### PR TITLE
fix: recover stale HNAP sessions and disable repeated reuse failures

### DIFF
--- a/packages/cable_modem_monitor_core/docs/ORCHESTRATION_SPEC.md
+++ b/packages/cable_modem_monitor_core/docs/ORCHESTRATION_SPEC.md
@@ -223,10 +223,14 @@ Example — successful collection with no channels:
 
 | Tier | Level | When | Purpose |
 |------|-------|------|---------|
-| Pulse | INFO always | Every successful poll | `"Parse complete [MODEL]: 24 DS, 4 US"` — heartbeat showing the modem is alive and parsing |
+| Pulse | INFO first poll, DEBUG after | Successful poll summaries | `"Parse complete [MODEL]: 24 DS, 4 US"` — visible at INFO for first-poll confirmation, then DEBUG in steady-state to keep success-path logs quiet |
 | Auth/resource | INFO first poll, DEBUG after | Steady-state noise reduction | Auth strategy, session state, resource loading. Visible at INFO for first-poll diagnostics, drops to DEBUG after to avoid flooding multi-modem logs |
 | Failures | WARNING/ERROR always | Never demoted | Auth failures, connectivity errors, parse errors. Always visible regardless of poll count |
 | Wire data | DEBUG always | Troubleshooting only | Request/response details, parsing internals |
+
+Status transitions and adaptive-reuse state changes stay at INFO even
+after the first poll. These are operator-relevant events, not
+steady-state heartbeat logs.
 
 ### Auth Log Level
 

--- a/packages/cable_modem_monitor_core/docs/ORCHESTRATION_SPEC.md
+++ b/packages/cable_modem_monitor_core/docs/ORCHESTRATION_SPEC.md
@@ -779,6 +779,13 @@ class OrchestratorDiagnostics:
             reachable.
         connectivity_backoff_remaining: Polls to skip before next
             connection attempt. 0 when no backoff active.
+        stale_session_recovery_streak: Consecutive recovered stale-
+            session events. Increments when a LOAD_AUTH same-poll
+            retry succeeds and resets on an intervening normal success
+            or unrecovered failure.
+        session_reuse_disabled: Whether the orchestrator has disabled
+            cached-session reuse for the rest of this runtime after
+            repeated consecutive stale-session recoveries.
         resource_fetches: Per-resource timing and size from the last
             successful collection. Empty list if never polled or
             collection failed before resource loading. Consumers
@@ -799,6 +806,8 @@ class OrchestratorDiagnostics:
     auth_strategy: str = ""
     connectivity_streak: int = 0
     connectivity_backoff_remaining: int = 0
+    stale_session_recovery_streak: int = 0
+    session_reuse_disabled: bool = False
     resource_fetches: list[ResourceFetch] = field(default_factory=list)
     last_poll_timestamp: float | None = None
 

--- a/packages/cable_modem_monitor_core/docs/ORCHESTRATION_USE_CASES.md
+++ b/packages/cable_modem_monitor_core/docs/ORCHESTRATION_USE_CASES.md
@@ -387,6 +387,11 @@ session was stale. Credentials are correct.
 - Streak resets to 0
 - Single LOAD_AUTH → same-poll fresh login → success is the expected
   self-healing path
+- The orchestrator increments a consecutive stale-session recovery
+  streak on each successful same-poll recovery
+- An intervening normal successful poll resets that streak
+- After 2 consecutive recovered stale sessions, later polls stop
+  attempting cached-session reuse and start with a fresh login
 
 ---
 
@@ -472,6 +477,8 @@ has expired the session (firmware timeout or max-session limit).
 - Successful retry does not increment auth failure streak
 - WARNING log: "HNAP HTTP 404 on reused session [MODEL] — session likely expired"
 - INFO logs show the retry and successful same-poll recovery
+- After the second consecutive recovered stale session, later polls
+  clear the cached session before collection and go straight to fresh auth
 
 **Note:** Some HNAP firmware returns 404 for expired sessions, not 401.
 Others may return 500. The routing does not depend on the specific status

--- a/packages/cable_modem_monitor_core/docs/ORCHESTRATION_USE_CASES.md
+++ b/packages/cable_modem_monitor_core/docs/ORCHESTRATION_USE_CASES.md
@@ -347,36 +347,46 @@ Session may be stale, or strategy doesn't grant data access.
 | 2 | Collector: auth succeeds (or session reused) | | |
 | 3 | Resource Loader: GET /status.html → HTTP 401 | | |
 | 4 | Collector returns `ModemResult(signal=LOAD_AUTH)` | | |
-| 5 | Orchestrator: streak++ | | |
-| 6 | Orchestrator: collector.clear_session() | session cleared | |
-| 7 | Return `ModemSnapshot(AUTH_FAILED)` | | |
+| 5 | Orchestrator: collector.clear_session() | session cleared | |
+| 6 | Orchestrator: retry collection once in same poll | | |
+| 7 | Retry still fails | | |
+| 8 | Orchestrator: streak++ | | |
+| 9 | Return `ModemSnapshot(AUTH_FAILED)` | | |
 
 **Assertions:**
 
-- Session is cleared so next poll starts with fresh login
+- Session is cleared before the same-poll retry
+- Orchestrator retries LOAD_AUTH once in the same poll
 - Auth failure streak is incremented (LOAD_AUTH is auth-related)
-- If persistent, will escalate to circuit breaker (same as wrong credentials)
+- If the retry also fails, the failure remains auth-related and can
+  still escalate to the circuit breaker
 - INFO log: "LOAD_AUTH — clearing session, reporting auth_failed..."
 
 ---
 
 ### UC-18: LOAD_AUTH — self-correcting stale session
 
-**Preconditions:** UC-17 occurred (session cleared). Credentials are correct.
+**Preconditions:** Data page returned LOAD_AUTH because the reused
+session was stale. Credentials are correct.
 
 | Step | Action | State change | Observable |
 |------|--------|-------------|------------|
 | 1 | Consumer calls `get_modem_data()` | | |
-| 2 | Collector: no session → fresh login → success | | |
-| 3 | Collector: load → parse → OK | | |
-| 4 | Orchestrator: streak→0 | streak reset | |
-| 5 | Return `ModemSnapshot(ONLINE)` | | |
+| 2 | Collector returns `ModemResult(signal=LOAD_AUTH)` | | |
+| 3 | Orchestrator: clear session | session cleared | |
+| 4 | Orchestrator: retry collection once in same poll | | |
+| 5 | Collector: no session → fresh login → success | | |
+| 6 | Collector: load → parse → OK | | |
+| 7 | Orchestrator: streak→0 | streak reset | |
+| 8 | Return `ModemSnapshot(ONLINE)` | | |
 
 **Assertions:**
 
-- Fresh login resolves the stale session
+- Fresh login resolves the stale session within the same poll
+- `auth_failed` is not surfaced when the retry succeeds
 - Streak resets to 0
-- Single LOAD_AUTH → fresh login → success is the expected self-healing path
+- Single LOAD_AUTH → same-poll fresh login → success is the expected
+  self-healing path
 
 ---
 
@@ -451,15 +461,17 @@ has expired the session (firmware timeout or max-session limit).
 | 2 | Collector: session valid (uid cookie + key) → reuse | | |
 | 3 | Resource Loader: POST /HNAP1/ with stale session → HTTP 404 | | |
 | 4 | Collector: HNAP error + reused session → LOAD_AUTH | | |
-| 5 | Orchestrator: streak++, collector.clear_session() | session cleared | |
-| 6 | Return `ModemSnapshot(AUTH_FAILED)` | | |
+| 5 | Orchestrator: collector.clear_session() | session cleared | |
+| 6 | Orchestrator: retry collection once in same poll | | |
+| 7 | Collector: fresh login → HNAP load → parse → OK | | ONLINE |
 
 **Assertions:**
 
 - Signal is LOAD_AUTH (not LOAD_ERROR) — session context determines routing
-- Session is cleared so next poll starts with fresh login (→ UC-18)
-- Auth failure streak is incremented
+- Session is cleared before the same-poll retry (→ UC-18)
+- Successful retry does not increment auth failure streak
 - WARNING log: "HNAP HTTP 404 on reused session [MODEL] — session likely expired"
+- INFO logs show the retry and successful same-poll recovery
 
 **Note:** Some HNAP firmware returns 404 for expired sessions, not 401.
 Others may return 500. The routing does not depend on the specific status
@@ -617,7 +629,7 @@ Modem has come back online.
 **Assertions:**
 
 - Transition is logged: "Status transition [MODEL]: unreachable → online"
-- If stale session rejected (3a): next poll does fresh login, self-corrects (UC-18)
+- If stale session rejected (3a): same poll does fresh login, self-corrects (UC-18)
 - No proactive session clear — LOAD_AUTH handles it naturally
 
 ---
@@ -1753,8 +1765,9 @@ password work on the next attempt. Retrying with known-bad credentials:
 
 **Distinguishing AUTH_FAILED from LOAD_AUTH:** LOAD_AUTH (401/403 on a
 data page after successful login) is a session issue, not a credential
-issue. LOAD_AUTH clears the session and the next poll re-authenticates
-fresh — this is self-correcting (UC-18). AUTH_FAILED is the modem
+issue. LOAD_AUTH clears the session and retries once in the same poll;
+if that fresh login succeeds, the condition self-corrects (UC-18).
+AUTH_FAILED is the modem
 rejecting the login itself.
 
 > **Status:** UC-20 documents the current behavior (threshold=6).

--- a/packages/cable_modem_monitor_core/docs/RUNTIME_POLLING_SPEC.md
+++ b/packages/cable_modem_monitor_core/docs/RUNTIME_POLLING_SPEC.md
@@ -310,6 +310,15 @@ login attempts. The auth manager reuses the session (cookies + HNAP
 private key) as long as it's valid. This is critical — logging in every
 poll triggers the lockout.
 
+**Adaptive reuse disable** — some firmware keeps the local session
+looking valid while the server has already expired it, which produces a
+same-poll `LOAD_AUTH` recovery loop on every reused-session poll. After
+2 consecutive recovered stale-session events, the orchestrator stops
+attempting session reuse for the rest of that process lifetime and
+starts each poll with a fresh login. An intervening normal successful
+poll resets the recovery streak. This state is runtime-only —
+`reset_auth()` or process restart re-enables reuse.
+
 **Login backoff** — after a `LoginLockoutError` (firmware anti-brute-force
 triggered), the orchestrator suppresses login for 3 polls. This gives the
 modem time to clear its lockout state. The counter decrements each poll
@@ -348,6 +357,8 @@ strategy returns `AuthResult.FAILURE`.
 | Login backoff counter | Orchestrator | Anti-brute-force suppression | Decremented each poll |
 | Auth failure streak | Orchestrator | Circuit breaker threshold tracking | Reset on successful collection |
 | Circuit open flag | Orchestrator | Stops polling on persistent auth failure | Cleared by client reauth |
+| Stale-session recovery streak | Orchestrator | Tracks consecutive recovered `LOAD_AUTH` same-poll retries | Reset by an intervening normal success, `reset_auth()`, or process restart |
+| Session reuse disabled flag | Orchestrator | Forces fresh auth on each poll after repeated consecutive stale-session recoveries | Reset by `reset_auth()` or process restart |
 | Connectivity streak | Orchestrator | Tracks consecutive unreachable failures | Reset on success, non-connectivity failure, reset_connectivity(), or health recovery |
 | Connectivity backoff | Orchestrator | Exponential backoff: min(2^(streak-1), 6) | Decremented each poll, cleared by reset_connectivity() or health recovery |
 | Last poll status | Orchestrator | Detect status transitions (e.g., unreachable → online) | Updated each poll |

--- a/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/models.py
+++ b/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/models.py
@@ -188,6 +188,13 @@ class OrchestratorDiagnostics:
             reachable.
         connectivity_backoff_remaining: Polls to skip before next
             connection attempt. 0 when no backoff active.
+        stale_session_recovery_streak: Consecutive recovered stale-
+            session events. Increments when a LOAD_AUTH same-poll retry
+            succeeds and resets on an intervening normal success or
+            unrecovered failure.
+        session_reuse_disabled: Whether the orchestrator has stopped
+            attempting cached-session reuse for the rest of this
+            runtime after repeated consecutive stale-session recoveries.
         resource_fetches: Per-resource timing and size from the last
             successful collection.
         last_poll_timestamp: Monotonic time of last get_modem_data()
@@ -201,6 +208,8 @@ class OrchestratorDiagnostics:
     auth_strategy: str = ""
     connectivity_streak: int = 0
     connectivity_backoff_remaining: int = 0
+    stale_session_recovery_streak: int = 0
+    session_reuse_disabled: bool = False
     resource_fetches: list[ResourceFetch] = field(default_factory=list)
     last_poll_timestamp: float | None = None
 
@@ -214,6 +223,8 @@ class OrchestratorDiagnostics:
             "auth_strategy": self.auth_strategy,
             "connectivity_streak": self.connectivity_streak,
             "connectivity_backoff_remaining": self.connectivity_backoff_remaining,
+            "stale_session_recovery_streak": self.stale_session_recovery_streak,
+            "session_reuse_disabled": self.session_reuse_disabled,
             "resource_fetches": [f.to_dict() for f in self.resource_fetches],
             "last_poll_timestamp": self.last_poll_timestamp,
         }

--- a/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/orchestrator.py
+++ b/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/orchestrator.py
@@ -91,6 +91,10 @@ class Orchestrator:
         # reset_auth(), DEBUG on steady-state
         self._first_poll_complete: bool = False
 
+        # Reuse-disable logging — INFO on the first forced fresh-login
+        # poll after adaptive disable, DEBUG on steady-state.
+        self._session_reuse_disabled_logged: bool = False
+
         # Counter-reset detection — proxy for "last boot time" when
         # the modem doesn't report native uptime (see #110)
         self._prev_error_totals: tuple[int, int] | None = None  # (corrected, uncorrected)
@@ -167,6 +171,7 @@ class Orchestrator:
         self._policy.reset()
         self._collector.clear_session()
         self._first_poll_complete = False
+        self._session_reuse_disabled_logged = False
         _logger.info("Auth state reset — next poll will attempt fresh login")
 
     def reset_connectivity(self) -> None:
@@ -309,10 +314,12 @@ class Orchestrator:
         self._log_poll_context()
 
         if not self._policy.should_attempt_session_reuse() and self._collector.session_is_valid:
-            _logger.info(
+            log = _logger.info if not self._session_reuse_disabled_logged else _logger.debug
+            log(
                 "Session reuse disabled [%s] — clearing session before poll",
                 self._modem_config.model,
             )
+            self._session_reuse_disabled_logged = True
             self._collector.clear_session()
 
         # Notify health monitor — avoids redundant HTTP probe during collection

--- a/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/orchestrator.py
+++ b/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/orchestrator.py
@@ -91,10 +91,6 @@ class Orchestrator:
         # reset_auth(), DEBUG on steady-state
         self._first_poll_complete: bool = False
 
-        # Reuse-disable logging — INFO on the first forced fresh-login
-        # poll after adaptive disable, DEBUG on steady-state.
-        self._session_reuse_disabled_logged: bool = False
-
         # Counter-reset detection — proxy for "last boot time" when
         # the modem doesn't report native uptime (see #110)
         self._prev_error_totals: tuple[int, int] | None = None  # (corrected, uncorrected)
@@ -171,7 +167,6 @@ class Orchestrator:
         self._policy.reset()
         self._collector.clear_session()
         self._first_poll_complete = False
-        self._session_reuse_disabled_logged = False
         _logger.info("Auth state reset — next poll will attempt fresh login")
 
     def reset_connectivity(self) -> None:
@@ -314,12 +309,10 @@ class Orchestrator:
         self._log_poll_context()
 
         if not self._policy.should_attempt_session_reuse() and self._collector.session_is_valid:
-            log = _logger.info if not self._session_reuse_disabled_logged else _logger.debug
-            log(
+            _logger.debug(
                 "Session reuse disabled [%s] — clearing session before poll",
                 self._modem_config.model,
             )
-            self._session_reuse_disabled_logged = True
             self._collector.clear_session()
 
         # Notify health monitor — avoids redundant HTTP probe during collection

--- a/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/orchestrator.py
+++ b/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/orchestrator.py
@@ -195,6 +195,8 @@ class Orchestrator:
             auth_strategy=auth.strategy if auth else "",
             connectivity_streak=self._policy.connectivity_streak,
             connectivity_backoff_remaining=self._policy.connectivity_backoff_remaining,
+            stale_session_recovery_streak=self._policy.stale_session_recovery_streak,
+            session_reuse_disabled=self._policy.session_reuse_disabled,
             resource_fetches=self._collector.last_resource_fetches,
             last_poll_timestamp=self._last_poll_timestamp,
         )
@@ -306,11 +308,19 @@ class Orchestrator:
         # Log poll context — INFO on first poll, DEBUG on steady-state
         self._log_poll_context()
 
+        if not self._policy.should_attempt_session_reuse() and self._collector.session_is_valid:
+            _logger.info(
+                "Session reuse disabled [%s] — clearing session before poll",
+                self._modem_config.model,
+            )
+            self._collector.clear_session()
+
         # Notify health monitor — avoids redundant HTTP probe during collection
         if self._health_monitor is not None:
             self._health_monitor.record_collection_start()
 
         collection_success = False
+        load_auth_recovered = False
         try:
             result = self._collector.execute()
             collection_success = result.success
@@ -318,10 +328,15 @@ class Orchestrator:
             if not result.success and result.signal is CollectorSignal.LOAD_AUTH:
                 result = self._retry_load_auth_once()
                 collection_success = result.success
+                load_auth_recovered = result.success
 
             if not result.success:
+                self._policy.reset_stale_session_recovery_streak()
                 self._log_poll_result(result)
                 return self._handle_failure(result)
+
+            if not load_auth_recovered:
+                self._policy.reset_stale_session_recovery_streak()
 
             self._first_poll_complete = True
             self._log_poll_result(result)
@@ -346,6 +361,7 @@ class Orchestrator:
 
         retry_result = self._collector.execute()
         if retry_result.success:
+            self._policy.record_stale_session_recovery()
             _logger.info(
                 "LOAD_AUTH recovered [%s] — fresh login succeeded in same poll",
                 self._modem_config.model,

--- a/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/orchestrator.py
+++ b/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/orchestrator.py
@@ -315,6 +315,10 @@ class Orchestrator:
             result = self._collector.execute()
             collection_success = result.success
 
+            if not result.success and result.signal is CollectorSignal.LOAD_AUTH:
+                result = self._retry_load_auth_once()
+                collection_success = result.success
+
             if not result.success:
                 self._log_poll_result(result)
                 return self._handle_failure(result)
@@ -325,6 +329,29 @@ class Orchestrator:
         finally:
             if self._health_monitor is not None:
                 self._health_monitor.record_collection_end(collection_success)
+
+    def _retry_load_auth_once(self) -> ModemResult:
+        """Retry one LOAD_AUTH failure immediately with a fresh session.
+
+        LOAD_AUTH represents session expiry or stale auth state, not
+        credential rejection. Clear the current session and allow one
+        fresh collection attempt in the same poll to smooth over HNAP
+        session expiry without falling back to the next scheduled poll.
+        """
+        _logger.info(
+            "LOAD_AUTH [%s] — clearing session and retrying once in same poll",
+            self._modem_config.model,
+        )
+        self._collector.clear_session()
+
+        retry_result = self._collector.execute()
+        if retry_result.success:
+            _logger.info(
+                "LOAD_AUTH recovered [%s] — fresh login succeeded in same poll",
+                self._modem_config.model,
+            )
+
+        return retry_result
 
     def _handle_failure(self, result: ModemResult) -> ModemSnapshot:
         """Apply signal policy for a failed collection."""

--- a/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/orchestrator.py
+++ b/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/orchestrator.py
@@ -338,8 +338,8 @@ class Orchestrator:
             if not load_auth_recovered:
                 self._policy.reset_stale_session_recovery_streak()
 
-            self._first_poll_complete = True
             self._log_poll_result(result)
+            self._first_poll_complete = True
             return self._handle_success(result)
         finally:
             if self._health_monitor is not None:
@@ -502,7 +502,7 @@ class Orchestrator:
         )
 
     def _log_poll_result(self, result: ModemResult) -> None:
-        """Log poll outcome. Parse line at INFO always. Failure at WARNING."""
+        """Log poll outcome. First success at INFO, steady-state at DEBUG."""
         model = self._modem_config.model
 
         if not result.success:
@@ -517,7 +517,8 @@ class Orchestrator:
         ds = len(result.modem_data.get("downstream", [])) if result.modem_data else 0
         us = len(result.modem_data.get("upstream", [])) if result.modem_data else 0
 
-        _logger.info(
+        log = _logger.info if not self._first_poll_complete else _logger.debug
+        log(
             "Parse complete [%s]: %d DS, %d US channels",
             model,
             ds,

--- a/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/policy.py
+++ b/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/policy.py
@@ -197,7 +197,7 @@ class SignalPolicy:
             self._auth_failure_streak += 1
             self._collector.clear_session()
             _logger.info(
-                "LOAD_AUTH [%s] — clearing session, reporting auth_failed (streak: %d/%d)",
+                "LOAD_AUTH [%s] — retry failed, reporting auth_failed (streak: %d/%d)",
                 self._model,
                 self._auth_failure_streak,
                 self._threshold,

--- a/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/policy.py
+++ b/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/orchestration/policy.py
@@ -47,15 +47,19 @@ class SignalPolicy:
         collector: ModemDataCollector,
         auth_failure_threshold: int = 6,
         max_connectivity_backoff: int = 6,
+        stale_recovery_threshold: int = 2,
         model: str = "",
     ) -> None:
         self._collector = collector
         self._threshold = auth_failure_threshold
         self._max_connectivity_backoff = max_connectivity_backoff
+        self._stale_recovery_threshold = stale_recovery_threshold
         self._model = model
 
         self._auth_failure_streak: int = 0
         self._circuit_open: bool = False
+        self._stale_session_recovery_streak: int = 0
+        self._session_reuse_disabled: bool = False
 
         # Connectivity backoff — separate from auth
         self._connectivity_streak: int = 0
@@ -80,6 +84,57 @@ class SignalPolicy:
     def connectivity_backoff_remaining(self) -> int:
         """Polls remaining in the connectivity backoff window."""
         return self._connectivity_backoff
+
+    @property
+    def stale_session_recovery_streak(self) -> int:
+        """Current consecutive recovered stale-session streak."""
+        return self._stale_session_recovery_streak
+
+    @property
+    def session_reuse_disabled(self) -> bool:
+        """Whether session reuse is disabled for the current runtime."""
+        return self._session_reuse_disabled
+
+    def should_attempt_session_reuse(self) -> bool:
+        """Whether the next poll should try the cached session first."""
+        return not self._session_reuse_disabled
+
+    def record_stale_session_recovery(self) -> None:
+        """Record a consecutive same-poll stale-session recovery.
+
+        After repeated consecutive recovered LOAD_AUTH events, disable
+        session reuse for the rest of the runtime to avoid burning the
+        first request of each poll on firmware with chronically short
+        session TTLs.
+        """
+        if self._session_reuse_disabled:
+            return
+
+        self._stale_session_recovery_streak += 1
+        if self._stale_session_recovery_streak < self._stale_recovery_threshold:
+            return
+
+        self._session_reuse_disabled = True
+        _logger.info(
+            "Recovered stale-session streak reached threshold [%s] — "
+            "disabling session reuse for this runtime "
+            "(%d consecutive recoveries)",
+            self._model,
+            self._stale_session_recovery_streak,
+        )
+
+    def reset_stale_session_recovery_streak(self) -> None:
+        """Reset the consecutive stale-session recovery streak.
+
+        A normal successful poll or any unrecovered failure breaks the
+        pattern. Once session reuse is disabled, the threshold-reaching
+        streak is left intact for diagnostics until reset_auth() or
+        process restart.
+        """
+        if self._session_reuse_disabled:
+            return
+
+        self._stale_session_recovery_streak = 0
 
     def check_connectivity_backoff(self) -> bool:
         """Check and decrement the connectivity backoff counter.
@@ -131,7 +186,7 @@ class SignalPolicy:
         if signal == CollectorSignal.AUTH_LOCKOUT:
             self._auth_failure_streak += 1
             _logger.warning(
-                "Auth lockout [%s] — firmware anti-brute-force triggered, " "stopping immediately (streak: %d)",
+                "Auth lockout [%s] — firmware anti-brute-force triggered, stopping immediately (streak: %d)",
                 self._model,
                 self._auth_failure_streak,
             )
@@ -142,7 +197,7 @@ class SignalPolicy:
             self._auth_failure_streak += 1
             self._collector.clear_session()
             _logger.info(
-                "LOAD_AUTH [%s] — clearing session, reporting auth_failed " "(streak: %d/%d)",
+                "LOAD_AUTH [%s] — clearing session, reporting auth_failed (streak: %d/%d)",
                 self._model,
                 self._auth_failure_streak,
                 self._threshold,
@@ -158,7 +213,7 @@ class SignalPolicy:
             )
             self._connectivity_backoff = backoff
             _logger.warning(
-                "Connection failure [%s] — unreachable (streak: %d, " "backoff: %d polls)",
+                "Connection failure [%s] — unreachable (streak: %d, backoff: %d polls)",
                 self._model,
                 self._connectivity_streak,
                 backoff,
@@ -184,6 +239,8 @@ class SignalPolicy:
         """
         self._auth_failure_streak = 0
         self._circuit_open = False
+        self._stale_session_recovery_streak = 0
+        self._session_reuse_disabled = False
         self._connectivity_streak = 0
         self._connectivity_backoff = 0
 

--- a/packages/cable_modem_monitor_core/tests/orchestration/test_models.py
+++ b/packages/cable_modem_monitor_core/tests/orchestration/test_models.py
@@ -218,6 +218,8 @@ class TestOrchestratorDiagnostics:
             "auth_strategy": "",
             "connectivity_streak": 0,
             "connectivity_backoff_remaining": 0,
+            "stale_session_recovery_streak": 0,
+            "session_reuse_disabled": False,
             "resource_fetches": [],
             "last_poll_timestamp": None,
         }

--- a/packages/cable_modem_monitor_core/tests/orchestration/test_orchestrator.py
+++ b/packages/cable_modem_monitor_core/tests/orchestration/test_orchestrator.py
@@ -452,10 +452,7 @@ class TestStreakReset:
         )
         orch = _make_orchestrator(collector=collector)
 
-        orch.get_modem_data()  # LOAD_AUTH: streak → 1 (session issue, not credential rejection)
-        assert orch.diagnostics().auth_failure_streak == 1
-
-        orch.get_modem_data()  # success → streak → 0
+        orch.get_modem_data()  # LOAD_AUTH retried in same poll, success keeps streak at 0
         assert orch.diagnostics().auth_failure_streak == 0
         assert orch.diagnostics().circuit_breaker_open is False
 
@@ -527,7 +524,7 @@ class TestCircuitBreaker:
 
     def test_load_auth_uses_threshold(self) -> None:
         """LOAD_AUTH is a session issue — circuit trips at threshold, not immediately."""
-        results = [_fail_result(CollectorSignal.LOAD_AUTH) for _ in range(5)]
+        results = [_fail_result(CollectorSignal.LOAD_AUTH) for _ in range(10)]
         collector = _mock_collector(results)
         orch = _make_orchestrator(collector=collector)
 
@@ -566,7 +563,7 @@ class TestLoadAuth:
     """UC-17/18/19: LOAD_AUTH signal handling."""
 
     def test_load_auth_clears_session(self) -> None:
-        """UC-17: LOAD_AUTH clears session and increments streak."""
+        """UC-17: LOAD_AUTH clears session and increments streak on retry failure."""
         collector = _mock_collector(_fail_result(CollectorSignal.LOAD_AUTH))
         orch = _make_orchestrator(collector=collector)
 
@@ -574,10 +571,11 @@ class TestLoadAuth:
 
         assert snapshot.connection_status == ConnectionStatus.AUTH_FAILED
         assert orch.diagnostics().auth_failure_streak == 1
-        collector.clear_session.assert_called_once()
+        assert collector.execute.call_count == 2
+        collector.clear_session.assert_called()
 
-    def test_load_auth_self_corrects(self) -> None:
-        """UC-18: LOAD_AUTH → fresh login → success."""
+    def test_load_auth_recovers_in_same_poll(self) -> None:
+        """UC-18: LOAD_AUTH retries once immediately and returns success."""
         collector = _mock_collector(
             [
                 _fail_result(CollectorSignal.LOAD_AUTH),
@@ -586,15 +584,33 @@ class TestLoadAuth:
         )
         orch = _make_orchestrator(collector=collector)
 
-        orch.get_modem_data()  # LOAD_AUTH, session cleared
-        snapshot = orch.get_modem_data()  # fresh login → success
+        snapshot = orch.get_modem_data()
+
+        assert snapshot.connection_status == ConnectionStatus.ONLINE
+        assert orch.diagnostics().auth_failure_streak == 0
+        assert collector.execute.call_count == 2
+        collector.clear_session.assert_called_once()
+
+    def test_load_auth_self_corrects(self) -> None:
+        """UC-18: a later successful poll leaves the streak clear."""
+        collector = _mock_collector(
+            [
+                _fail_result(CollectorSignal.LOAD_AUTH),
+                _ok_result(),
+                _ok_result(),
+            ]
+        )
+        orch = _make_orchestrator(collector=collector)
+
+        orch.get_modem_data()  # LOAD_AUTH retried in same poll → success
+        snapshot = orch.get_modem_data()  # steady-state success
 
         assert snapshot.connection_status == ConnectionStatus.ONLINE
         assert orch.diagnostics().auth_failure_streak == 0
 
     def test_load_auth_escalates_to_circuit(self) -> None:
         """Persistent LOAD_AUTH eventually trips circuit breaker."""
-        results = [_fail_result(CollectorSignal.LOAD_AUTH) for _ in range(6)]
+        results = [_fail_result(CollectorSignal.LOAD_AUTH) for _ in range(12)]
         collector = _mock_collector(results)
         orch = _make_orchestrator(collector=collector)
 
@@ -1004,7 +1020,7 @@ class TestUnplannedRestart:
     """UC-49: Modem restarted externally — recovery through normal polling."""
 
     def test_outage_and_recovery_sequence(self) -> None:
-        """ONLINE → UNREACHABLE (with backoff) → LOAD_AUTH → ONLINE."""
+        """ONLINE → UNREACHABLE (with backoff) → LOAD_AUTH retry → ONLINE."""
         collector = _mock_collector()
         orch = _make_orchestrator(collector=collector)
 
@@ -1018,19 +1034,16 @@ class TestUnplannedRestart:
         snap = orch.get_modem_data()
         assert snap.connection_status == ConnectionStatus.UNREACHABLE
 
-        # Poll 3: Backoff clears, modem back but stale session — LOAD_AUTH
-        collector.execute.return_value = _fail_result(CollectorSignal.LOAD_AUTH, "401 on data page")
+        # Poll 3: Backoff clears, modem back but stale session — retry succeeds same poll
+        collector.execute.side_effect = [
+            _fail_result(CollectorSignal.LOAD_AUTH, "401 on data page"),
+            _ok_result(),
+        ]
         snap = orch.get_modem_data()
-        assert snap.connection_status == ConnectionStatus.AUTH_FAILED
-        # Session should have been cleared by LOAD_AUTH policy
+        assert snap.connection_status == ConnectionStatus.ONLINE
         collector.clear_session.assert_called()
         # Connectivity cleared because modem responded
         assert orch.diagnostics().connectivity_streak == 0
-
-        # Poll 4: Fresh login succeeds — ONLINE
-        collector.execute.return_value = _ok_result()
-        snap = orch.get_modem_data()
-        assert snap.connection_status == ConnectionStatus.ONLINE
 
     def test_connectivity_never_trips_circuit_breaker(self) -> None:
         """CONNECTIVITY failures never trip the auth circuit breaker."""
@@ -1046,7 +1059,7 @@ class TestUnplannedRestart:
         assert not orch.diagnostics().circuit_breaker_open
 
     def test_stale_session_self_corrects(self, caplog: pytest.LogCaptureFixture) -> None:
-        """LOAD_AUTH clears session, next poll authenticates fresh."""
+        """LOAD_AUTH clears session and recovers within the same poll."""
         collector = _mock_collector()
         orch = _make_orchestrator(collector=collector)
 
@@ -1055,16 +1068,15 @@ class TestUnplannedRestart:
         orch.get_modem_data()
 
         # Stale session detected
-        collector.execute.return_value = _fail_result(CollectorSignal.LOAD_AUTH, "401 on data page")
+        collector.execute.side_effect = [
+            _fail_result(CollectorSignal.LOAD_AUTH, "401 on data page"),
+            _ok_result(),
+        ]
         with caplog.at_level(logging.INFO):
-            orch.get_modem_data()
+            snap = orch.get_modem_data()
 
         assert "LOAD_AUTH" in caplog.text
-        collector.clear_session.assert_called()
-
-        # Fresh login succeeds
-        collector.execute.return_value = _ok_result()
-        snap = orch.get_modem_data()
+        collector.clear_session.assert_called_once()
         assert snap.connection_status == ConnectionStatus.ONLINE
 
 

--- a/packages/cable_modem_monitor_core/tests/orchestration/test_orchestrator.py
+++ b/packages/cable_modem_monitor_core/tests/orchestration/test_orchestrator.py
@@ -619,6 +619,93 @@ class TestLoadAuth:
 
         assert orch.diagnostics().circuit_breaker_open is True
 
+    def test_load_auth_recovery_streak_resets_on_normal_success(self) -> None:
+        """A normal poll breaks the consecutive stale-session recovery streak."""
+        collector = _mock_collector(
+            [
+                _fail_result(CollectorSignal.LOAD_AUTH),
+                _ok_result(),
+                _ok_result(),
+                _fail_result(CollectorSignal.LOAD_AUTH),
+                _ok_result(),
+            ]
+        )
+        orch = _make_orchestrator(collector=collector)
+
+        orch.get_modem_data()
+        diag = orch.diagnostics()
+        assert diag.stale_session_recovery_streak == 1
+        assert diag.session_reuse_disabled is False
+
+        orch.get_modem_data()
+        diag = orch.diagnostics()
+        assert diag.stale_session_recovery_streak == 0
+        assert diag.session_reuse_disabled is False
+
+        orch.get_modem_data()
+        diag = orch.diagnostics()
+        assert diag.stale_session_recovery_streak == 1
+        assert diag.session_reuse_disabled is False
+
+    def test_load_auth_disables_reuse_after_two_consecutive_recoveries(self) -> None:
+        """Two consecutive stale-session recoveries disable reuse for this runtime."""
+        collector = _mock_collector(
+            [
+                _fail_result(CollectorSignal.LOAD_AUTH),
+                _ok_result(),
+                _fail_result(CollectorSignal.LOAD_AUTH),
+                _ok_result(),
+                _ok_result(),
+            ]
+        )
+        orch = _make_orchestrator(collector=collector)
+
+        orch.get_modem_data()
+        diag = orch.diagnostics()
+        assert diag.stale_session_recovery_streak == 1
+        assert diag.session_reuse_disabled is False
+
+        orch.get_modem_data()
+        diag = orch.diagnostics()
+        assert diag.stale_session_recovery_streak == 2
+        assert diag.session_reuse_disabled is True
+
+        collector.clear_session.reset_mock()
+        orch.get_modem_data()
+
+        assert collector.execute.call_count == 5
+        collector.clear_session.assert_called_once()
+
+    def test_reset_auth_clears_adaptive_reuse_state(self) -> None:
+        """Credential reset re-enables session reuse and clears the counter."""
+        collector = _mock_collector(
+            [
+                _fail_result(CollectorSignal.LOAD_AUTH),
+                _ok_result(),
+                _fail_result(CollectorSignal.LOAD_AUTH),
+                _ok_result(),
+                _fail_result(CollectorSignal.LOAD_AUTH),
+                _ok_result(),
+            ]
+        )
+        orch = _make_orchestrator(collector=collector)
+
+        orch.get_modem_data()
+        orch.get_modem_data()
+        assert orch.diagnostics().session_reuse_disabled is True
+
+        orch.reset_auth()
+
+        diag = orch.diagnostics()
+        assert diag.stale_session_recovery_streak == 0
+        assert diag.session_reuse_disabled is False
+
+        collector.clear_session.reset_mock()
+        orch.get_modem_data()
+
+        assert collector.execute.call_count == 6
+        collector.clear_session.assert_called_once()
+
 
 class TestPasswordChanged:
     """UC-87: Password changed — circuit trips on first AUTH_FAILED."""


### PR DESCRIPTION
# Description

Retry `LOAD_AUTH` failures once after clearing the cached session so stale HNAP sessions recover without surfacing a transient `auth_failed` state.

On the affected modem, the auth timeout is shorter than the 10 minute poll interval, so reused sessions can expire between polls. This keeps those polls successful without requiring a manual refresh or a follow-up poll to authenticate fresh.

This PR also adds adaptive session reuse protection for modems that repeatedly expire reused sessions between polls. After 2 consecutive successful same-poll `LOAD_AUTH` recoveries, the orchestrator disables cached session reuse for the rest of the runtime and starts future polls with a fresh login. An intervening normal successful poll resets the recovery streak. This keeps the integration from burning the first request of every poll on firmware with chronically short session TTLs.

## Type of Change

<!-- Please check the relevant option(s) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvement
- [ ] CI/CD improvement
- [ ] Dependency update

## Related Issues

Related to #140

## Changes Made

Add a one-time same-poll re-auth retry when a cached session expires.

Add adaptive session reuse handling:
- track consecutive successful stale-session recoveries
- disable cached session reuse after 2 consecutive recoveries
- reset the recovery streak after an intervening normal successful poll
- expose the adaptive reuse state in orchestrator diagnostics

Adjust steady-state logging so routine successful parse-complete logs fall back to debug after the first successful poll, while failure, recovery, and reuse-disable transitions remain visible at info/warning level.

## Testing

Full test suite passed locally (`make test`)

Focused orchestration tests were updated and passed as well

### Test Configuration

- **Integration Version**: 3.14.0 beta
- **Home Assistant Version**: 2026.4.0
- **Modem Model** (if applicable): Arris S33

### Test Steps

1. Run the full local test suite
2. Run focused orchestration tests for the touched slice
3. Test with a real Arris S33 modem
4. Verify same-poll `LOAD_AUTH` recovery succeeds without a transient `auth_failed` state
5. Verify 2 consecutive recovered stale sessions disable cached session reuse for the rest of the runtime
6. Verify later polls start with a fresh login after reuse is disabled

### Test Results

- [X] All existing tests pass
- [X] New tests added (if applicable)
- [X] Manual testing completed
- [ ] Pre-commit hooks pass

## Screenshots (if applicable)

<img width="504" height="315" alt="image" src="https://github.com/user-attachments/assets/af73c8c1-bf5a-455d-bb60-fe8e12694c8c" />

## Checklist

<!-- Please check all items that apply -->

### Code Quality

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have run the linter (`make lint` or `ruff check`)
- [X] I have run the code formatter (`make format` or `black .`)

### Testing

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`make test` or `pytest`)
- [X] I have tested this integration with a real modem (if applicable)

### Documentation

- [X] I have updated the documentation accordingly (README, CHANGELOG, etc.)
- [ ] I have updated the CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/) format
- [X] I have added docstrings to new functions/classes
- [X] I have updated type hints (if applicable)

### For New Modem Support

<!-- Only applicable if adding support for a new modem model.
     The recommended path is the catalog_tools intake pipeline
     (/modem-intake skill), which generates configs from a HAR capture.
     See CONTRIBUTING.md § AI-Assisted Catalog Contribution. -->

- [ ] HAR captured with [`har-capture`](https://github.com/solentlabs/har-capture) (auto-sanitizes PII)
- [ ] Modem directory created: `packages/cable_modem_monitor_catalog/.../modems/<manufacturer>/<model>/`
- [ ] Contains: `modem.yaml`, `parser.yaml`, `test_data/modem.har`, `test_data/modem.expected.json`
- [ ] Catalog test suite discovers and passes for the new modem (`pytest packages/cable_modem_monitor_catalog/tests/`)
- [ ] Tested with actual modem hardware

### Compliance

- [ ] My changes respect user privacy and security
- [X] I have read and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [X] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [X] My commit messages follow the project's commit message guidelines

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here and provide migration instructions -->

None / N/A

## Additional Notes

Manual testing on the Arris S33 confirmed the stale-session behavior that motivated this change:
- reused sessions can expire between the 10 minute polls
- same-poll retry recovers cleanly
- after 2 consecutive recovered stale sessions, cached session reuse is disabled for the rest of the runtime
- subsequent polls continue successfully with fresh login instead of surfacing transient auth failures

## For Maintainers

<!-- Maintainers only - do not fill out -->

- [ ] Version bump required?
- [ ] Release notes drafted?
- [ ] Ready to merge?