### PR TITLE
fix(catalog): arris s33 reboot fix

### DIFF
--- a/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/arris/s33/modem.yaml
+++ b/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/arris/s33/modem.yaml
@@ -15,6 +15,8 @@ actions:
     action_name: SetArrisConfigurationInfo
     params:
       Action: reboot
+      SetEEEEnable: ${ethSWEthEEE:0}
+      LED_Status: ${LedStatus:1}
     pre_fetch_action: GetArrisConfigurationInfo
     response_key: SetArrisConfigurationInfoResponse
     result_key: SetArrisConfigurationInfoResult
@@ -48,6 +50,8 @@ notes: |
   HNAP protocol uses GetCustomer* action names (vs MB8611's GetMoto*).
   JavaScript reveals identical protocol structure to MB8611.
   Session stored in sessionStorage.getItem('PrivateKey').
+  Restart payload preserves current EEE and LED values from
+  GetArrisConfigurationInfo before sending Action=reboot.
   S33 blocks ICMP ping - HTTP-only health checks required.
   Modem UI swaps CustomerConnSystemUpTime display with clock time (JS bug); HNAP API returns real uptime.
   Compatible: S33v2 (same parser, MD5 HMAC), S33v3 (same parser, SHA256 HMAC).
@@ -56,3 +60,4 @@ references:
     - "[#32 — [Modem Request] Arris S33 - Uptime and Frequency Fixes](https://github.com/solentlabs/cable_modem_monitor/issues/32)"
     - "[#87 — [Bug]: S33 OFDM Channel No Longer Reporting](https://github.com/solentlabs/cable_modem_monitor/issues/87)"
     - "[#117 — [Bug]: Arris S33v2 crashing when monitor enabled](https://github.com/solentlabs/cable_modem_monitor/issues/117)"
+    - "[#146 — [Bug]: Arris S33 Modem Reboot Not Working](https://github.com/solentlabs/cable_modem_monitor/issues/146)"


### PR DESCRIPTION
# Description

Fix the Arris S33 reboot handling so the catalog-side reboot flow works correctly on the `feature/v3.14.0-beta` line.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement
- [ ] CI/CD improvement
- [ ] Dependency update

## Related Issues

Related to #146 

## Changes Made

- Corrected the Arris S33 reboot handling in the catalog workflow
- Kept the change scoped to the S33 reboot fix without mixing in unrelated feature work
- Verified the change against the local automated test suite before preparing this PR

## Testing

### Test Configuration

- **Integration Version**: `feature/v3.14.0-beta` with this PR branch applied
- **Home Assistant Version**: Local automated test environment
- **Modem Model** (if applicable): Arris S33

### Test Steps

1. Apply the S33 reboot fix on top of `feature/v3.14.0-beta`.
2. Run the full local test suite with `make test`.
3. Re-run focused validation for the affected project surfaces:
   - `pytest tests/ -q --tb=short --cov=solentlabs/cable_modem_monitor_catalog_tools --cov-report=term:skip-covered --cov-fail-under=80`
   - `pytest tests/ -o addopts= -q --tb=short --strict-markers --cov=custom_components/cable_modem_monitor --cov-report=term:skip-covered --cov-fail-under=70`

### Test Results

- [x] All existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed
- [ ] Pre-commit hooks pass

## Screenshots (if applicable)

N/A

## Checklist

### Code Quality

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have run the linter (`make lint` or `ruff check`)
- [ ] I have run the code formatter (`make format` or `black .`)

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`make test` or `pytest`)
- [ ] I have tested this integration with a real modem (if applicable)

### Documentation

- [ ] I have updated the documentation accordingly (README, CHANGELOG, etc.)
- [ ] I have updated the CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/) format
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated type hints (if applicable)

### For New Modem Support

- [ ] HAR captured with [`har-capture`](https://github.com/solentlabs/har-capture) (auto-sanitizes PII)
- [ ] Modem directory created: `packages/cable_modem_monitor_catalog/.../modems/<manufacturer>/<model>/`
- [ ] Contains: `modem.yaml`, `parser.yaml`, `test_data/modem.har`, `test_data/modem.expected.json`
- [ ] Catalog test suite discovers and passes for the new modem (`pytest packages/cable_modem_monitor_catalog/tests/`)
- [ ] Tested with actual modem hardware

### Compliance

- [x] My changes respect user privacy and security
- [x] I have read and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My commit messages follow the project's commit message guidelines

## Breaking Changes

None / N/A

## Additional Notes

This PR is intentionally narrow and only carries the Arris S33 reboot fix so it can be reviewed independently from the migration/reconciliation work and the HACS testing documentation work.

## For Maintainers

- [ ] Version bump required?
- [ ] Release notes drafted?
- [ ] Ready to merge?
