### PR TITLE
Draft: Proposal only - signal health specification baseline

### DIFF
--- a/custom_components/cable_modem_monitor/docs/CONFIG_FLOW_SPEC.md
+++ b/custom_components/cable_modem_monitor/docs/CONFIG_FLOW_SPEC.md
@@ -332,6 +332,7 @@ Configure.
 - Host, username, password (without re-selecting modem)
 - Data poll interval (30s–86400s, or disabled for manual-only)
 - Health check interval (10s–86400s, or disabled)
+- Signal Health thresholds and enablement
 - Full reconfiguration (restart from Step 1)
 
 **What cannot change without reconfiguration:**
@@ -343,6 +344,50 @@ Configure.
 configurable, including disabled. See
 [HA_ADAPTER_SPEC.md](HA_ADAPTER_SPEC.md#polling-modes) for the
 complete matrix and interval limits.
+
+### Signal-health settings
+
+Signal Health adds enough configuration surface that it is not appended
+as a long tail of fields to the current
+connection settings form.
+
+Form shape:
+
+- main options menu
+- `connection_settings` sub-form for host, credentials, and intervals
+- `signal_health` sub-form for the summary sensor thresholds and
+   enablement
+
+Why this shape:
+
+- connection changes need live modem validation
+- signal-health threshold changes should use local-only validation
+- a separate sub-form is clearer than a long mixed form with two very
+   different validation models
+
+Signal-health threshold changes still give immediate feedback after the
+form closes. The UX is:
+
+- local-only validation before save
+- save to `entry.options`
+- entry reload via the normal update-listener path
+- immediate fresh modem-data poll during reload so the recalculated grade is
+   visible right away
+
+Users should not need to wait for the normal scheduled data interval after a
+rare threshold adjustment.
+
+The `signal_health` form does not expose every evaluator threshold for user
+modification. It exposes only the thresholds that are intentionally
+user-configurable. Physical or standards-backed limits that define hard-failure
+territory remain fixed in the evaluator contract unless the specification moves
+them into the user-facing options surface.
+
+A dedicated `signal_health` form is reached from the main options menu.
+
+Signal-health options live in `entry.options`, not `entry.data`.
+The HA adapter reads them, builds a typed thresholds object, and passes
+that object into Core's evaluator on each update.
 
 ---
 

--- a/custom_components/cable_modem_monitor/docs/ENTITY_MODEL_SPEC.md
+++ b/custom_components/cable_modem_monitor/docs/ENTITY_MODEL_SPEC.md
@@ -11,6 +11,12 @@ in standard HA format. Users derive additional entities (template
 sensors, binary_sensors) from attributes as needed. The integration
 does not create entities for every possible use case.
 
+**Exception:** The adapter may add a small number of curated,
+high-value interpretation entities when they summarize normalized modem
+telemetry in a reusable, automation-friendly way and would otherwise
+force users to rebuild the same logic in templates. Signal Health is
+the example of this exception.
+
 ---
 
 ## Contents
@@ -94,6 +100,30 @@ parser output → no entity created.
 | Ping Latency | `_ping_latency` | float | — | MEASUREMENT | ms | `supports_icmp = True` |
 | TCP Latency | `_tcp_latency` | float | — | MEASUREMENT | ms | Health coordinator exists (HTTP probe enabled) |
 | HTTP Latency | `_http_latency` | float | — | MEASUREMENT | ms | `supports_head = True` (HEAD-only — no GET fallback for bimodal-corrupted data) |
+
+### Signal Health Sensor
+
+The integration exposes this summary sensor:
+
+| Entity | unique_id suffix | State | Condition | Notes |
+|--------|-----------------|-------|-----------|-------|
+| Signal Health | `_signal_health` | `good`, `fair`, `poor` | Always created as a top-level summary entity; unavailable only when current `modem_data` is absent | Summarizes RF health from normalized DOCSIS telemetry |
+
+The Signal Health sensor is a curated interpretation entity, not a raw
+modem field. Its purpose is to translate channel telemetry into one
+actionable grade plus compact diagnostic context.
+
+Its design constraints are:
+
+- Core owns the grading rules and typed result models
+- HA owns persistence of user-configurable thresholds in `entry.options`
+- the entity remains available when only one metric is provisional
+  (for example, first-poll error-rate baseline establishment)
+- missing unsupported metrics are omitted from grading rather than
+  replaced with modem-specific heuristics
+
+See `CONFIG_FLOW_SPEC.md` for the options-flow shape and
+`HA_ADAPTER_SPEC.md` for runtime and persistence expectations.
 
 ### Per-Channel Downstream Sensors
 
@@ -375,6 +405,7 @@ over with its own unique_id.
 | Field names, types, units | `device_class`, `state_class`, `unit_of_measurement` |
 | Implicit capabilities (field present = capable) | Entity created if field present |
 | Health check results (latency, reachability) | Health sensor entities |
+| Signal-health evaluation over normalized telemetry | Signal Health sensor state, summaries, translations, and availability |
 | `ActionFactory` (restart support) | Button entities |
 | Channel normalization (`channel_number`, `channel_type`, `channel_id`) | Mapping manager builds slot maps; entity unique_id incorporates mode-dependent key |
 
@@ -518,6 +549,34 @@ Channel sensor names depend on identity mode:
 
 - **Position mode:** `"{DIR} Ch {n} {Metric}"` — no channel type in
   the name. Positions are unique by definition and type-agnostic.
+
+---
+
+## Entity Translations And Icons
+
+Platinum-quality entities must use Home Assistant's standard
+translation and icon mechanisms rather than hardcoded UI strings where
+the platform supports translation-driven behavior.
+
+For new top-level curated entities such as Signal Health
+sensor:
+
+- add `translations/en.json` entries as the source of truth
+- add best-effort matching entries to every shipped translation file
+- use `translation_key` on the entity where appropriate
+- add `icons.json` entries for state-based icons when the entity's
+  state model benefits from icon translation
+
+For the Signal Health sensor specifically:
+
+- `en.json` must include the entity name and any user-facing option
+  labels or descriptions
+- the other shipped language files should receive best-effort matching
+  entries in the same change
+- `icons.json` should map `good`, `fair`, and `poor` to distinct icons
+
+This requirement exists because a flagship summary entity is part of
+the primary user experience, not an internal-only metric surface.
   Example: "DS Ch 1 Power".
 - **ID mode:** `"{DIR} {TYPE} Ch {ID} {Metric}"` — channel type
   included for DOCSIS 3.1 disambiguation.

--- a/custom_components/cable_modem_monitor/docs/HA_ADAPTER_SPEC.md
+++ b/custom_components/cable_modem_monitor/docs/HA_ADAPTER_SPEC.md
@@ -124,7 +124,7 @@ layer can cause spurious integration reloads or lost state on restart.
 |-------|----------|----------------|---------|
 | `entry.runtime_data` | Process lifetime; cleared on unload/reload | None | Live Core objects (orchestrator, coordinators), channel map |
 | `entry.data` | Persistent across restarts | Fires update listener → integration reload | User config (host, credentials), validation-derived fields, write-once markers |
-| `entry.options` | Persistent across restarts | Same as `entry.data` | User-editable settings from the options flow (`scan_interval`, `health_check_interval`) |
+| `entry.options` | Persistent across restarts | Same as `entry.data` | User-editable settings from the options flow (`scan_interval`, `health_check_interval`, signal-health thresholds) |
 | `Store` helper | Persistent across restarts | None — silent writes | Runtime state that mutates at poll cadence (e.g., channel-bond baseline) |
 
 **Picking a layer:**
@@ -150,6 +150,33 @@ user deletes the config entry.
 
 Follow the same pattern for future runtime-state domains: one module,
 one typed payload, load / save / remove helpers, cleanup hook.
+
+### Signal-health state split
+
+Signal Health uses the persistence layers as
+follows:
+
+- `entry.options` stores user-configurable thresholds and enablement
+- `entry.runtime_data` may hold a small in-memory baseline for metrics
+  that require prior successful samples, such as error-rate velocity
+- no persistent Store state is required for the initial design; the
+  first successful sample after startup re-establishes baseline
+
+The HA adapter is responsible for reading `entry.options`, building a
+typed thresholds object, and passing that object into the Core
+signal-health evaluator. Core does not read Home Assistant storage
+directly.
+
+Threshold-only changes do not perform live modem validation before the options
+form is saved. They still produce immediate feedback after save. The path is:
+
+- save signal-health settings to `entry.options`
+- let the normal update-listener path reload the entry
+- rely on `async_setup_entry`'s mandatory first poll to fetch fresh modem data
+  immediately on reload
+
+This preserves the clean separation between local form validation and modem I/O
+while still avoiding a poor user experience after a threshold change.
 
 ---
 
@@ -963,7 +990,7 @@ current channel data.
 ### `request_refresh`
 
 Triggers an immediate modem data poll, bypassing connectivity backoff.
-Intended for automations that need on-demand polling (e.g., "ping
+Used by automations that need on-demand polling (e.g., "ping
 fails → trigger modem check").
 
 **Fields:** Optional `device_id` (device selector filtered to
@@ -1203,6 +1230,19 @@ correct types and defaults). Use generic names for migration test
 data. Catalog resolution algorithms (`resolve_modem_dir`) are tested
 with synthetic `ModemSummary` data — not the real catalog.
 
+**Translations and icons are part of the feature surface.** For any new
+top-level entity with user-facing significance, adapter tests and review
+checklists must verify:
+
+- `translations/en.json` contains the source-of-truth strings
+- best-effort matching entries were added for the other shipped
+  translation files in the same change
+- `icons.json` contains any required state-based icons
+- the entity uses translation-driven naming and icon patterns where HA
+  supports them
+
+Signal Health is explicitly in this category.
+
 ---
 
 ## Module Inventory
@@ -1228,6 +1268,8 @@ The HA adapter layer consists of these modules:
 | `core/log_buffer.py` | Log capture for diagnostics (HA adapter + Core package loggers) |
 | `lib/host_validation.py` | URL building, host input parsing |
 | `lib/utils.py` | Utility functions (e.g., uptime parsing) |
+| `translations/*.json` | Source English plus best-effort shipped-language translations for user-facing strings |
+| `icons.json` | State-based icon translations for entities that need icon mapping |
 
 All modem-specific logic lives in Core and Catalog. The adapter
 imports from `solentlabs.cable_modem_monitor_core` and

--- a/packages/cable_modem_monitor_core/docs/README.md
+++ b/packages/cable_modem_monitor_core/docs/README.md
@@ -17,6 +17,7 @@
 | [FORMAT_JSON_SPEC.md](FORMAT_JSON_SPEC.md) | JSONParser and JSONTransposedParser — JSON API responses, including indexed-pivot rows |
 | [FORMAT_XML_SPEC.md](FORMAT_XML_SPEC.md) | XMLParser — XML element children via tag name navigation |
 | [SYSTEM_INFO_SPEC.md](SYSTEM_INFO_SPEC.md) | system_info extraction — multi-source, format schemas, field tiers |
+| [SIGNAL_HEALTH_EVALUATION_SPEC.md](SIGNAL_HEALTH_EVALUATION_SPEC.md) | Signal-health grading — thresholds, DOCSIS trust rule, metric groups, result contract |
 | [RESOURCE_LOADING_SPEC.md](RESOURCE_LOADING_SPEC.md) | Resource dict contract, loader behavior, HNAP batching |
 | [ORCHESTRATION_SPEC.md](ORCHESTRATION_SPEC.md) | Orchestrator, collector, health monitor, restart monitor — interface contracts and data models |
 | [ORCHESTRATION_USE_CASES.md](ORCHESTRATION_USE_CASES.md) | 81 scenario-based use cases — normal ops, auth failures, connectivity, restart, health, lifecycle |

--- a/packages/cable_modem_monitor_core/docs/SIGNAL_HEALTH_EVALUATION_SPEC.md
+++ b/packages/cable_modem_monitor_core/docs/SIGNAL_HEALTH_EVALUATION_SPEC.md
@@ -1,0 +1,383 @@
+# Signal Health Evaluation Specification
+
+> Parent specs: [ORCHESTRATION_SPEC.md](ORCHESTRATION_SPEC.md) —
+> runtime data models and snapshot contract,
+> [RUNTIME_POLLING_SPEC.md](RUNTIME_POLLING_SPEC.md) — poll cadence and
+> `docsis_status` derivation,
+> [PARSING_SPEC.md](PARSING_SPEC.md) — normalized channel fields and
+> aggregate system_info fields
+
+This specification governs how Core evaluates normalized modem telemetry
+into a compact signal-health result. The evaluation is platform-agnostic:
+it does not know about Home Assistant entities, options flows,
+translations, or icons. Consumers provide the current snapshot,
+user-selected thresholds, and optional prior-sample context; Core
+returns typed result data only.
+
+## Contents
+
+| Section | What it covers |
+|---------|----------------|
+| [Purpose](#purpose) | What this evaluator is for and what it is not for |
+| [Design principles](#design-principles) | Platform boundaries and invariants |
+| [Public API](#public-api) | Evaluator inputs and outputs |
+| [Threshold model](#threshold-model) | Typed threshold input contract |
+| [Result model](#result-model) | Typed result payload returned by Core |
+| [DOCSIS trust rule](#docsis-trust-rule) | Locked-only trust model for RF grading |
+| [Metric groups](#metric-groups) | Evaluated groups and comparison semantics |
+| [Evaluation flow](#evaluation-flow) | Ordered evaluation steps |
+| [Tie-breaking](#tie-breaking) | Deterministic decisive-metric selection |
+| [Baseline-dependent metrics](#baseline-dependent-metrics) | Error-rate initialization and provisional values |
+| [Consumer responsibilities](#consumer-responsibilities) | What the platform layer must do |
+
+---
+
+## Purpose
+
+The signal-health evaluator answers one question:
+
+```text
+Given the current normalized modem snapshot and a threshold profile,
+what is the current signal-health grade and which metric group decided it?
+```
+
+The evaluator produces a compact, machine-readable result suitable for:
+
+- Home Assistant sensor attributes
+- automations
+- diagnostics output
+- other non-HA consumers
+
+It does not produce:
+
+- translated display strings
+- icon names
+- entity availability decisions
+- persisted baseline storage
+- Home Assistant-specific metadata
+
+Those belong to the consumer layer.
+
+---
+
+## Design principles
+
+1. **Core is data-first.** Return typed values and machine-readable
+   reason codes, not UI phrasing.
+2. **Core does not read platform storage.** Thresholds and baselines
+   are passed in by the consumer.
+3. **Only trusted DOCSIS state may be graded.** Anything less than
+   locked forces `poor`.
+4. **Metric groups are independent.** Each group yields one grade and
+   one observed value summary.
+5. **The worst group wins.** The final grade is determined by the most
+   severe metric group, subject to the DOCSIS trust rule.
+6. **Unsupported and provisional are different.** Unsupported means the
+   modem does not expose the data. Provisional means the metric exists
+   but one more sample is needed.
+7. **Results must be deterministic.** The same inputs always produce
+   the same decisive metric and same channel selection.
+
+---
+
+## Public API
+
+Core-facing contract:
+
+```python
+@dataclass(frozen=True)
+class SignalHealthBaseline:
+    total_uncorrected: int
+    sampled_at: datetime
+
+
+@dataclass(frozen=True)
+class SignalHealthEvaluationInput:
+    snapshot: ModemSnapshot
+    thresholds: SignalHealthThresholds
+    baseline: SignalHealthBaseline | None = None
+
+
+def evaluate_signal_health(
+    evaluation: SignalHealthEvaluationInput,
+) -> SignalHealthResult:
+    """Evaluate normalized modem telemetry into a signal-health result."""
+```
+
+Notes:
+
+- `snapshot` is the current normalized Core snapshot
+- `thresholds` is a typed profile built by the consumer from user
+  options and fixed limits
+- `baseline` is optional prior-sample context for error-rate
+  evaluation
+
+The function is pure with respect to consumer state:
+
+- no Home Assistant imports
+- no I/O
+- no logging side effects required for correctness
+- no mutation of the provided snapshot
+
+---
+
+## Threshold model
+
+Thresholds are consumer-supplied, but the model is owned by Core.
+
+```python
+@dataclass(frozen=True)
+class SignalHealthThresholds:
+    downstream_power_fair_max: float
+    downstream_power_poor_max: float
+    upstream_power_good_min: float
+    upstream_power_good_max: float
+    upstream_power_poor_min: float
+    upstream_power_poor_max: float
+    snr_fair_min: float
+    snr_poor_min: float
+    downstream_power_delta_fair_max: float
+    downstream_power_delta_poor_max: float
+    error_rate_fair_max: float
+    error_rate_poor_max: float
+```
+
+Rules:
+
+- fixed physical or standards-backed limits may still be represented in
+  this model even when the consumer does not expose them in the UI
+- the evaluator uses only the values it was passed, not hidden
+  fallback constants in evaluation logic
+- the consumer decides which values are user-configurable and which are
+  fixed constants
+
+---
+
+## Result model
+
+Core returns a typed, compact result designed for structured consumers.
+
+```python
+class SignalHealthGrade(StrEnum):
+    GOOD = "good"
+    FAIR = "fair"
+    POOR = "poor"
+
+
+@dataclass(frozen=True)
+class SignalHealthMetricResult:
+    grade: SignalHealthGrade
+    observed: float | str | None
+    unit: str | None
+    comparison: str
+    thresholds: dict[str, float | str | list[str]]
+    worst_channel: str | None = None
+    baseline_established: bool | None = None
+    provisional: bool | None = None
+    window_seconds: int | None = None
+    omitted: bool = False
+
+
+@dataclass(frozen=True)
+class SignalHealthResult:
+    grade: SignalHealthGrade
+    decisive_metric: str
+    non_good_metrics: dict[str, SignalHealthGrade]
+    channel_counts: dict[str, int]
+    metrics: dict[str, SignalHealthMetricResult]
+    evaluated_at: datetime
+```
+
+Contract rules:
+
+- `grade` is the final evaluator output
+- `decisive_metric` names the metric group that decided the result
+- `non_good_metrics` contains only metric groups currently graded
+  `fair` or `poor`
+- `metrics` contains one entry per supported metric group, plus
+  DOCSIS status
+- omitted metrics may still appear in `metrics` with `omitted=True` if
+  the consumer wants one stable schema; alternatively the consumer may
+  choose to drop omitted groups after evaluation
+
+Keep omitted groups explicit in the typed result so consumers do not have to
+infer why a group is missing.
+
+---
+
+## DOCSIS trust rule
+
+DOCSIS status is a first-class metric group, but it is also a trust
+boundary for the rest of RF grading.
+
+Evaluation rule:
+
+- only fully locked / operational DOCSIS state is trustworthy
+- any state less than locked forces final grade `poor`
+
+Expected canonical behavior:
+
+| Observed `docsis_status` | Metric grade | Effect |
+|--------------------------|--------------|--------|
+| `Operational` | `good` | Continue normal metric grading |
+| `locked` | `good` | Continue normal metric grading |
+| `partial_lock` | `poor` | Final grade forced to `poor` |
+| `not_locked` | `poor` | Final grade forced to `poor` |
+| `unknown` | `poor` | Final grade forced to `poor` unless the consumer proves it is a locked synonym before evaluation |
+
+Rationale:
+
+- if DOCSIS is not fully locked, RF values cannot be trusted
+- partial lock is not a warning tier for signal health; it is already a
+  failed trust state
+
+The evaluator still computes other metric groups when useful for
+diagnostics, but `decisive_metric` remains `docsis_status` and the final
+grade remains `poor`.
+
+---
+
+## Metric groups
+
+The evaluator operates over these metric groups:
+
+| Metric group | Observed value | Comparison | Channel-scoped |
+|--------------|----------------|------------|----------------|
+| `docsis_status` | enum string | `enum_status` | No |
+| `downstream_power` | worst absolute dBmV deviation | `absolute_distance_from_zero` | Yes |
+| `upstream_power` | worst transmit power | `inclusive_range` | Yes |
+| `snr` | worst downstream SNR | `minimum_floor` | Yes |
+| `downstream_power_delta` | downstream max-min spread | `spread` | No |
+| `error_rate` | uncorrectables per minute | `rate` | No |
+
+### Channel-scoped metric rules
+
+For channel-scoped groups, the evaluator reports one `worst_channel`.
+
+Selection rules:
+
+- evaluate only active channels for the metric
+- pick the worst-performing channel for that metric
+- if multiple channels tie, choose the lowest channel number
+- if channel number is unavailable for tie-break, choose the earliest
+  stable ordering from the normalized channel list
+
+### Comparison semantics
+
+`comparison` is a machine-readable hint for consumers and diagnostics.
+
+Canonical values:
+
+- `enum_status`
+- `absolute_distance_from_zero`
+- `inclusive_range`
+- `minimum_floor`
+- `spread`
+- `rate`
+
+Consumers treat these as stable identifiers, not translated UI
+strings.
+
+---
+
+## Evaluation flow
+
+The evaluator runs in this order:
+
+1. Read `snapshot.docsis_status` and evaluate the DOCSIS trust rule.
+2. Count active downstream and upstream channels for reporting.
+3. Evaluate each supported metric group independently.
+4. Build `non_good_metrics` from all metric groups graded `fair` or
+   `poor`.
+5. Select `decisive_metric` using severity first, then deterministic
+   ordering.
+6. Produce the final `SignalHealthResult`.
+
+Severity order:
+
+- `poor` beats `fair`
+- `fair` beats `good`
+
+If DOCSIS status is `poor`, final grade is `poor` regardless of all
+other metric grades.
+
+---
+
+## Tie-breaking
+
+Two kinds of tie-breaking must be deterministic.
+
+### Tied channels within one metric group
+
+Rule:
+
+- choose the lower channel number
+
+If the normalized data does not expose a comparable channel number,
+fall back to stable list order.
+
+### Tied metric groups across the final result
+
+If multiple metric groups share the same worst grade, choose
+`decisive_metric` by this stable precedence order:
+
+1. `docsis_status`
+2. `error_rate`
+3. `downstream_power_delta`
+4. `downstream_power`
+5. `upstream_power`
+6. `snr`
+
+Why this order:
+
+- DOCSIS trust failures invalidate all RF interpretation
+- error-rate is closest to user-facing service impact
+- downstream delta is a fleet-level imbalance signal, not one bad row
+- downstream and upstream power precede SNR because they represent the
+  primary hardware operating window in this design
+
+If this precedence changes, it must change here first.
+
+---
+
+## Baseline-dependent metrics
+
+`error_rate` depends on a previous successful sample.
+
+Rules:
+
+- if no baseline is provided, evaluate `error_rate` as `0.0` with
+  `provisional=True` and `baseline_established=False`
+- if a valid baseline is provided, compute delta over elapsed time and
+  convert to per-minute rate
+- if the total uncorrectables counter decreases, treat the metric as a
+  reset/restart case: `observed=0.0`, `provisional=True`,
+  `baseline_established=False`
+- if elapsed time is zero or negative, treat the metric as provisional
+
+This keeps the result stable and avoids making the whole signal-health
+entity unavailable just because one rate-based metric needs one more
+sample.
+
+---
+
+## Consumer responsibilities
+
+The consumer layer is responsible for:
+
+- building `SignalHealthThresholds` from user options and fixed
+  constants
+- deciding when evaluation runs
+- persisting and re-supplying the optional baseline
+- translating `SignalHealthResult` into entity state and attributes
+- adding any display summaries, translations, or icons
+
+The consumer layer is not allowed to:
+
+- reimplement grading math already specified here
+- reinterpret DOCSIS trust rules differently per platform
+- replace omitted or provisional Core results with platform-specific
+  heuristics
+
+That split is the architectural point of this spec: Core answers the
+cable-modem question, consumers decide how to present the answer.


### PR DESCRIPTION
# Description

This draft PR proposes the initial signal-health specification baseline for
Cable Modem Monitor.

The goal of this PR is to give reviewers a focused place to review the exact
spec changes, comment inline, and either approve the direction or request
changes before implementation begins.

A key gating decision in moving forward with this proposal is whether to accept a change in the entity-model boundary described in ENTITY_MODEL_SPEC.md:8. That section currently defines the integration as exposing modem-provided data rather than analysis or derived interpretation, so approving Signal Health means explicitly allowing a curated summary entity as an exception to that rule.

This PR is for specification review only. It does not implement the feature.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement
- [ ] CI/CD improvement
- [ ] Dependency update

## Related Issues

Related to #144

## Proposal Summary

This proposal defines the signal-health feature as:

- a curated summary sensor for modem RF health
- a Core-owned evaluation contract with a thin HA adapter
- a Home Assistant options surface that exposes only selected
  user-configurable thresholds
- a strict DOCSIS trust rule where anything less than locked evaluates as poor
- a reload path that fetches fresh modem data after signal-health threshold
  changes so the updated result is visible immediately

## Documents In Scope

- `custom_components/cable_modem_monitor/docs/ENTITY_MODEL_SPEC.md`
- `custom_components/cable_modem_monitor/docs/CONFIG_FLOW_SPEC.md`
- `custom_components/cable_modem_monitor/docs/HA_ADAPTER_SPEC.md`
- `packages/cable_modem_monitor_core/docs/SIGNAL_HEALTH_EVALUATION_SPEC.md`

## Review Focus

Please review and comment on:

- whether the Core vs HA boundary is correct
- whether the signal-health evaluator contract is correct
- whether the options/config surface is appropriately scoped
- whether the DOCSIS and threshold semantics are correct
- whether any spec language should change before implementation starts

## Changes Made

- added and aligned the signal-health specification documents across the HA and
  Core doc sets
- normalized the spec language so the documents describe the intended baseline
  instead of implementation planning history
- clarified that the options flow does not expose every threshold, only the
  thresholds intentionally chosen for user configuration

## Testing

This PR is documentation-only. No runtime behavior or implementation code is
changed.

### Test Configuration

- **Integration Version**: N/A
- **Home Assistant Version**: N/A
- **Modem Model** (if applicable): N/A

### Test Steps

1. Review the changed specification documents in the PR diff
2. Confirm the proposed architecture and configuration boundaries
3. Comment inline on any requested changes or approval concerns

### Test Results

- [ ] All existing tests pass
- [ ] New tests added (if applicable)
- [x] Manual review of changed docs completed
- [ ] Pre-commit hooks pass

## Screenshots (if applicable)

N/A

## Checklist

### Code Quality

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have run the linter (`make lint` or `ruff check`)
- [ ] I have run the code formatter (`make format` or `black .`)

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`make test` or `pytest`)
- [ ] I have tested this integration with a real modem (if applicable)

### Documentation

- [x] I have updated the documentation accordingly (README, CHANGELOG, etc.)
- [ ] I have updated the CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/) format
- [ ] I have added docstrings to new functions/classes
- [ ] I have updated type hints (if applicable)

### For New Modem Support

- [ ] HAR captured with [`har-capture`](https://github.com/solentlabs/har-capture) (auto-sanitizes PII)
- [ ] Modem directory created: `packages/cable_modem_monitor_catalog/.../modems/<manufacturer>/<model>/`
- [ ] Contains: `modem.yaml`, `parser.yaml`, `test_data/modem.har`, `test_data/modem.expected.json`
- [ ] Catalog test suite discovers and passes for the new modem (`pytest packages/cable_modem_monitor_catalog/tests/`)
- [ ] Tested with actual modem hardware

### Compliance

- [x] My changes respect user privacy and security
- [x] I have read and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My commit messages follow the project's commit message guidelines

## Breaking Changes

None / N/A

## Additional Notes

This draft PR is intended to support approval and design discussion before any
implementation PR is opened.

## For Maintainers

- [ ] Version bump required?
- [ ] Release notes drafted?
- [ ] Ready to merge?