### PR TITLE
fix(deps): lower Core floors to HA-compatible versions; add HA compat gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -240,6 +240,28 @@ jobs:
         run: |
           python scripts/check_suppression_discipline.py --branch "${{ steps.base.outputs.ref }}"
 
+  ha-compat-check:
+    name: HA Dependency Compatibility
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install "homeassistant>=2025.1.0" packaging tomli
+
+      - name: Check Core/Catalog deps against HA constraints
+        run: |
+          python scripts/check_ha_compat.py
+
   catalog-readme:
     name: Catalog README
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,6 +328,14 @@ which reports only packages declared in our requirements files and
 pyproject.toml — not the transitive HA or test-harness tree. When it
 shows drift, propose a separate deps-update commit before pushing.
 
+**HA compatibility gate:** `validate-ci` runs `scripts/check_ha_compat.py`
+(mirrored by the `ha-compat-check` CI job), which validates that every floor
+declared in Core and Catalog's `pyproject.toml` is satisfiable under HA's
+`package_constraints.txt`. This is a hard gate — exit non-zero blocks the
+push. Never bump a floor in a published package's pyproject.toml above what
+HA constrains without first verifying compatibility (the beta.4 incident:
+`requests>=2.34.2` and `pyyaml>=6.0.3` both exceeded HA's pins).
+
 **CI job coverage:** When verifying CI after a push, confirm every
 expected job ran. A missing job is not a pass — absence of failure is
 not success. If a job didn't trigger, check the workflow's path filters

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-quick test-simple clean lint lint-fix fix-imports lint-all type-check format format-check check validate validate-ci validate-host intake-regression pii-check catalog-readme-check suppression-check install-hooks docker-start docker-stop docker-restart docker-logs docker-status docker-clean docker-shell
+.PHONY: help test test-quick test-simple clean lint lint-fix fix-imports lint-all type-check format format-check check validate validate-ci validate-host intake-regression pii-check catalog-readme-check suppression-check ha-compat-check install-hooks docker-start docker-stop docker-restart docker-logs docker-status docker-clean docker-shell
 
 # Pin tool invocations to the project venv so that subprocesses
 # without venv on PATH (release.py shelling out, fresh clones, CI
@@ -29,7 +29,7 @@ help:
 	@echo "  make check        - Run all code quality checks (lint, format, type)"
 	@echo "  make quick-check  - Quick checks (lint + format, skip type-check)"
 	@echo "  make validate-host - Cross-platform validation (auto-installs tools)"
-	@echo "  make validate-ci   - Full CI-like validation (lint + tests)"
+	@echo "  make validate-ci   - Full CI-like validation (lint + tests + ha-compat)"
 	@echo "  make install-hooks - Install optional pre-push hook (runs validate-ci)"
 	@echo ""
 	@echo "Docker Development:"
@@ -118,7 +118,7 @@ validate:
 # hacs/action@main, which runs in a GitHub-hosted Docker context with
 # external network checks against home-assistant/brands and HACS APIs;
 # not reasonably reproducible locally — same exception class as hassfest).
-validate-ci: check test intake-regression pii-check catalog-readme-check suppression-check
+validate-ci: check test intake-regression pii-check catalog-readme-check suppression-check ha-compat-check
 	@echo "✅ Full CI validation passed!"
 	@echo "🔍 Checking declared dependencies for available updates..."
 	@$(VENV_BIN)/python scripts/check_owned_deps.py
@@ -141,6 +141,14 @@ pii-check:
 suppression-check:
 	@echo "🔍 Scanning for unjustified suppressions..."
 	@$(VENV_BIN)/python scripts/check_suppression_discipline.py --branch origin/main
+
+# HA dependency compatibility — mirrors CI ha-compat-check job.
+# Validates that Core/Catalog declared dep floors are satisfiable under
+# HA's package_constraints.txt. Catches cases where a deps-bump sets a
+# floor above what HA pins (e.g., requests or pyyaml). Exit non-zero = gate.
+ha-compat-check:
+	@echo "🔍 Checking Core/Catalog deps against HA package constraints..."
+	@$(VENV_BIN)/python scripts/check_ha_compat.py
 
 # Catalog README freshness — mirrors CI catalog-readme job.
 catalog-readme-check:

--- a/packages/cable_modem_monitor_core/pyproject.toml
+++ b/packages/cable_modem_monitor_core/pyproject.toml
@@ -10,10 +10,10 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "beautifulsoup4>=4.12",
-    "pyyaml>=6.0.3",
+    "pyyaml>=6.0.0",
     "defusedxml>=0.7.1",
     "pydantic>=2.0",
-    "requests>=2.34.2",
+    "requests>=2.31.0",
 ]
 license = "MIT"
 authors = [

--- a/scripts/check_ha_compat.py
+++ b/scripts/check_ha_compat.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Validate Core and Catalog declared dependencies against HA's package constraints.
+
+Home Assistant pins specific package versions in package_constraints.txt. Library
+packages that declare floors above HA's pins will fail to install at runtime even
+though they install fine in a standalone environment (e.g., the beta.4 incident
+where requests>=2.34.2 and pyyaml>=6.0.3 both exceeded HA's pins).
+
+Exit non-zero if any conflict is found — this IS a build gate.
+"""
+
+import importlib.util
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+try:
+    from packaging.specifiers import SpecifierSet
+    from packaging.version import Version
+except ImportError:
+    print("  ERROR: 'packaging' library not found. Install requirements-dev.txt first.")
+    sys.exit(1)
+
+ROOT = Path(__file__).parent.parent
+
+_INTERNAL_PREFIX = "solentlabs-"
+
+
+def _normalize(name: str) -> str:
+    return re.sub(r"[-_.]", "-", name).lower()
+
+
+def _find_ha_constraints() -> Path | None:
+    spec = importlib.util.find_spec("homeassistant")
+    if not spec or not spec.submodule_search_locations:
+        return None
+    ha_dir = Path(list(spec.submodule_search_locations)[0])
+    path = ha_dir / "package_constraints.txt"
+    return path if path.exists() else None
+
+
+def _parse_ha_constraints(path: Path) -> dict[str, str]:
+    """Return {normalized_name: pinned_version} for all exact-pinned packages."""
+    pins: dict[str, str] = {}
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = re.match(r"^([A-Za-z0-9_.-]+)==([^\s;]+)", line)
+        if m:
+            pins[_normalize(m.group(1))] = m.group(2)
+    return pins
+
+
+def _parse_pyproject_deps(path: Path) -> list[tuple[str, str]]:
+    """Return [(normalized_name, specifier_string)] from [project.dependencies]."""
+    if not path.exists():
+        return []
+    data = tomllib.loads(path.read_text())
+    result = []
+    for dep in data.get("project", {}).get("dependencies", []):
+        m = re.match(r"^([A-Za-z0-9_.-]+)\s*(.*?)(?:\s*;.*)?$", dep.strip())
+        if not m:
+            continue
+        name = _normalize(m.group(1))
+        if name.startswith(_INTERNAL_PREFIX):
+            continue
+        spec = m.group(2).strip()
+        result.append((name, spec))
+    return result
+
+
+def main() -> int:
+    constraints_path = _find_ha_constraints()
+    if not constraints_path:
+        print("  homeassistant not installed — skipping HA compatibility check.")
+        return 0
+
+    ha_pins = _parse_ha_constraints(constraints_path)
+
+    pyprojects = [
+        ROOT / "packages" / "cable_modem_monitor_core" / "pyproject.toml",
+        ROOT / "packages" / "cable_modem_monitor_catalog" / "pyproject.toml",
+    ]
+
+    conflicts: list[str] = []
+
+    for pyproject in pyprojects:
+        pkg_label = pyproject.parent.name
+        for name, spec_str in _parse_pyproject_deps(pyproject):
+            if name not in ha_pins or not spec_str:
+                continue
+            ha_version = ha_pins[name]
+            try:
+                if Version(ha_version) not in SpecifierSet(spec_str):
+                    conflicts.append(
+                        f"  {pkg_label}: {name}{spec_str} — "
+                        f"HA pins {name}=={ha_version}, which does not satisfy"
+                        f" {spec_str}"
+                    )
+            except Exception as exc:
+                conflicts.append(f"  {pkg_label}: could not parse {name}{spec_str}: {exc}")
+
+    if conflicts:
+        noun = "conflict" if len(conflicts) == 1 else "conflicts"
+        print(f"  ❌ {len(conflicts)} HA compatibility {noun} found:")
+        for c in conflicts:
+            print(c)
+        print(
+            "  Fix: lower the floor in packages/cable_modem_monitor_core/pyproject.toml" " to a version HA can satisfy."
+        )
+        return 1
+
+    print("  ✅ All declared dependencies satisfy HA's package constraints.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- `requests>=2.34.2` → `>=2.31.0` and `pyyaml>=6.0.3` → `>=6.0.0` in Core's `pyproject.toml` — both exceeded HA 2025.1.x `package_constraints.txt` pins, causing beta.4 to fail to install in HA at runtime
- Adds `scripts/check_ha_compat.py` — validates Core/Catalog declared dep floors against HA's pinned versions; exit non-zero on conflict (hard gate)
- Wires `ha-compat-check` into `make validate-ci` and adds a matching CI job so this class of regression cannot ship again

## Test plan

- [x] `scripts/check_ha_compat.py` passes clean against fixed pyproject.toml
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)