### PR TITLE
feat: v3.14.0-beta.5 — HA dep floor fix + compat gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.14.0-beta.5] - 2026-05-20
+
+### Fixed
+
+- **HA install failure: Core dependency floors exceeded HA's pinned versions.**
+  `requests>=2.34.2` and `pyyaml>=6.0.3` in Core's `pyproject.toml` both
+  exceeded HA 2025.1.x pins (`requests==2.32.3`, `PyYAML==6.0.2`), causing uv
+  to fail with "No solution found" on every fresh install. Floors lowered to
+  `requests>=2.31.0` and `pyyaml>=6.0.0`. Addresses beta.4 install regression.
+
+### Added
+
+- **HA dependency compatibility gate.** `scripts/check_ha_compat.py` validates
+  that every floor declared in Core and Catalog `pyproject.toml` is satisfiable
+  under HA's `package_constraints.txt`. Wired into `make validate-ci` and the
+  `ha-compat-check` CI job so this class of regression is caught before push.
+
 ## [3.14.0-beta.4] - 2026-05-20
 
 ### Added

--- a/custom_components/cable_modem_monitor/const.py
+++ b/custom_components/cable_modem_monitor/const.py
@@ -8,7 +8,7 @@ from homeassistant.const import Platform
 
 # IMPORTANT: Do not edit VERSION manually!
 # Use: python scripts/release.py <version>
-VERSION = "3.14.0-beta.4"
+VERSION = "3.14.0-beta.5"
 
 DOMAIN = "cable_modem_monitor"
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON]

--- a/custom_components/cable_modem_monitor/manifest.json
+++ b/custom_components/cable_modem_monitor/manifest.json
@@ -17,8 +17,8 @@
     "solentlabs.cable_modem_monitor_catalog"
   ],
   "requirements": [
-    "solentlabs-cable-modem-monitor-core==3.14.0-beta.4",
-    "solentlabs-cable-modem-monitor-catalog==3.14.0-beta.4"
+    "solentlabs-cable-modem-monitor-core==3.14.0-beta.5",
+    "solentlabs-cable-modem-monitor-catalog==3.14.0-beta.5"
   ],
-  "version": "3.14.0-beta.4"
+  "version": "3.14.0-beta.5"
 }

--- a/packages/cable_modem_monitor_catalog/pyproject.toml
+++ b/packages/cable_modem_monitor_catalog/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solentlabs-cable-modem-monitor-catalog"
-version = "3.14.0-beta.4"
+version = "3.14.0-beta.5"
 description = "Cable Modem Monitor Catalog — modem config files and parser overrides"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "solentlabs-cable-modem-monitor-core==3.14.0-beta.4",
+    "solentlabs-cable-modem-monitor-core==3.14.0-beta.5",
 ]
 license = "MIT"
 authors = [

--- a/packages/cable_modem_monitor_core/pyproject.toml
+++ b/packages/cable_modem_monitor_core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solentlabs-cable-modem-monitor-core"
-version = "3.14.0-beta.4"
+version = "3.14.0-beta.5"
 description = "Cable Modem Monitor Core — platform-agnostic DOCSIS monitoring engine"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -23,7 +23,7 @@
     },
     {
       "root": "packages/cable_modem_monitor_catalog_tools",
-      "extraPaths": ["."]
+      "extraPaths": [".", "packages/cable_modem_monitor_core"]
     }
   ]
 }

--- a/tests/components/test_version_and_startup.py
+++ b/tests/components/test_version_and_startup.py
@@ -22,7 +22,7 @@ class TestVersion:
         Use: python scripts/release.py <version>
         The script updates const.py, manifest.json, and this file.
         """
-        assert VERSION == "3.14.0-beta.4"
+        assert VERSION == "3.14.0-beta.5"
 
     def test_startup_log_message_format(self):
         """The startup log line includes the version string."""


### PR DESCRIPTION
## Summary

- Lowers Core dep floors that exceeded HA 2025.1.x pins (`requests>=2.31.0`, `pyyaml>=6.0.0`), fixing the uv resolver failure on fresh HA install introduced in beta.4
- Adds `scripts/check_ha_compat.py` as a hard gate: validates every floor in Core and Catalog `pyproject.toml` against HA's `package_constraints.txt`; wired into `make validate-ci` and a new `ha-compat-check` CI job
- Fixes `pyrightconfig.json`: adds Core to the catalog_tools execution environment so `tests._helpers` resolves (pytest adds Core via `pythonpath`; pyright did not)

## Test plan

- [ ] `make validate-ci` green locally (ran by release script)
- [ ] All CI jobs green on this branch
- [ ] After merge + tag: install beta.5 in HA and confirm no uv resolver error

Related to #167