### PR TITLE
feat: v3.14.0-beta.16 - DM1000 polling fix, button logbook fix, null_values sentinels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,8 +48,8 @@ body:
       label: Modem Model Selection in Config
       description: In the integration settings, which modem model did you select?
       options:
-        - auto (automatic detection)
-        - Manually selected my specific model
+        - Selected my exact model from the picker
+        - Selected a similar model (mine isn't listed)
         - Not sure / Don't remember
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/modem_request.yml
+++ b/.github/ISSUE_TEMPLATE/modem_request.yml
@@ -88,7 +88,7 @@ body:
         4. If your modem requires login, **log out** before closing the browser
         5. Close the browser when done
 
-        **Before sharing:** Search the `.sanitized.har` file for your WiFi password and any other credentials — the sanitizer is best-effort. See the [Modem Request Guide](https://github.com/solentlabs/cable_modem_monitor/blob/main/docs/MODEM_REQUEST.md#important-about-pii-and-sanitization) for what to check.
+        **Before sharing:** Search the `.sanitized.har` file for your WiFi password and any other credentials — the sanitizer is best-effort. See the [Modem Request Guide](https://github.com/solentlabs/cable_modem_monitor/blob/main/docs/MODEM_REQUEST.md#step-2--review-for-pii) for what to check.
 
         Attach the `.sanitized.har.gz` file to this issue.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -234,7 +234,7 @@ Modem Model and Channel Identity are install-time choices, not editable here. Th
 
 ## Available Sensors
 
-All sensors use the `cable_modem_` prefix for consistent entity naming and easy identification.
+All sensors use the `cable_modem_` prefix for consistent entity naming and easy identification. Supporting entities (system information, error totals and rates, latency, LAN statistics) sit in the device page's Diagnostic section.
 
 **Entity Naming Pattern:**
 
@@ -266,20 +266,26 @@ Channel Identity is set when you add the integration. To switch, remove and re-a
 
 ### System Information
 
+- **Modem Info**: Detected model, with manufacturer, DOCSIS version, release date, and catalog status as attributes
 - `sensor.cable_modem_software_version`: Modem firmware/software version
 - `sensor.cable_modem_last_boot_time`: When the modem last rebooted (timestamp device class); Home Assistant renders it as relative age ("5 days ago"), which doubles as uptime
 - `sensor.cable_modem_ds_channel_count`: Number of active downstream channels
 - `sensor.cable_modem_us_channel_count`: Number of active upstream channels
 
+Firmware and hardware versions also appear on the device info card. Other system fields your modem reports (provisioned speeds, for example) become sensors automatically, and LAN interface statistics get per-interface sensors for bytes, packets, errors, and drops.
+
 ### Latency Monitoring
 
 - `sensor.cable_modem_ping_latency`: Ping response time in milliseconds
+- `sensor.cable_modem_tcp_latency`: TCP connect time in milliseconds
 - `sensor.cable_modem_http_latency`: HTTP response time in milliseconds
 
 ### Summary Sensors
 
 - `sensor.cable_modem_total_corrected_errors`: Total corrected errors across all downstream channels
 - `sensor.cable_modem_total_uncorrected_errors`: Total uncorrected errors across all downstream channels
+- `sensor.cable_modem_rate_corrected_errors`: Corrected errors per minute
+- `sensor.cable_modem_rate_uncorrected_errors`: Uncorrected errors per minute
 
 ### Per-Channel Downstream Sensors (for each channel)
 
@@ -312,6 +318,7 @@ The integration registers three buttons under the modem device:
 - **`cable_modem_monitor.request_refresh`**: Triggers an immediate data poll for the selected device.
 - **`cable_modem_monitor.request_health_check`**: Runs an immediate health probe (ICMP / TCP / HTTP) outside the regular cadence.
 - **`cable_modem_monitor.convert_channel_identity`**: Renames recorder statistics from the previous Channel Identity mode to the current one, so historical graphs survive a remove-and-re-add in the other mode. Modem must be online.
+- **`cable_modem_monitor.orphaned_statistics`**: Lists recorder statistics left behind by a mode switch, channel rebonding, or a prefix change; call again with `execute: true` to purge them. See [Ghost Statistics in History](https://github.com/solentlabs/cable_modem_monitor/blob/main/docs/TROUBLESHOOTING.md#ghost-statistics-in-history).
 
 ## Understanding the Values
 
@@ -415,6 +422,10 @@ Please see the [Contributing Guide](https://github.com/solentlabs/cable_modem_mo
 MIT License - see LICENSE file for details
 
 ## Support
+
+Cable Modem Monitor is maintained by one person, in the evenings, around a day job. I read every issue, and replies are best effort; a few days is normal. Fixes land as time allows.
+
+Catalog contributions are welcome and are the fastest way to get a new modem supported. If you have AI access, you can do most of the intake yourself: see [AI-Assisted Catalog Contribution](https://github.com/solentlabs/cable_modem_monitor/blob/main/CONTRIBUTING.md#ai-assisted-catalog-contribution).
 
 - [GitHub Issues](https://github.com/solentlabs/cable_modem_monitor/issues)
 - [Home Assistant Community Forum](https://community.home-assistant.io/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **har-capture floor raised to 0.10.3.** The 0.10.3 sanitizer closes
+  a credential-leak gap (the Sercomm `pws` login field) found during
+  the DM1000 intake; catalog tooling now requires it. (Related to #92)
+
 ## [3.14.0-beta.15] - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **One button press, one logbook entry.** The restart button's
+  availability toggle wrote state during the press, so a single press
+  rendered as three "Pressed" logbook entries. The toggle is dropped in
+  favor of the frontend's native in-flight feedback, and all three
+  buttons now share the operation mutex the adapter spec defines:
+  restart converts to it, Reset Entities gains the double-click guard
+  it was missing, and Update Modem Data refuses presses during
+  destructive operations.
+
 - **DM1000 polling failed on every cycle since beta.10.** Channels
   built by parser.py hooks (the DM1000 OFDMA upstream) missed Core's
   channel_number pass and failed event payload validation, leaving all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.14.0-beta.16] - 2026-07-24
+
 ### Added
 
 - **`null_values` parser.yaml option.** JSON field mappings can declare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`null_values` parser.yaml option.** JSON field mappings can declare
+  firmware no-value sentinels, which then skip silently as sparse data
+  while undeclared shapes keep their warning. The DM1000 declares `---`
+  for its inactive upstream slots, removing four warning lines per
+  poll. (Related to #92)
+
 ### Changed
 
 - **har-capture floor raised to 0.10.3.** The 0.10.3 sanitizer closes
   a credential-leak gap (the Sercomm `pws` login field) found during
   the DM1000 intake; catalog tooling now requires it. (Related to #92)
+
+### Fixed
+
+- **DM1000 polling failed on every cycle since beta.10.** Channels
+  built by parser.py hooks (the DM1000 OFDMA upstream) missed Core's
+  channel_number pass and failed event payload validation, leaving all
+  entities unavailable. Core now numbers hook-built channels after
+  hooks run, and a new fleet test validates every catalog golden
+  against the event payload schema, so this class of gap fails CI
+  instead of production polls. (Related to #92)
 
 ## [3.14.0-beta.15] - 2026-07-22
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,7 +4,7 @@ This document outlines the governance model for the Cable Modem Monitor project.
 
 ## Project Overview
 
-Cable Modem Monitor is a community-driven open-source project that provides Home Assistant integration for monitoring cable modem statistics. The project is maintained by volunteers who contribute their time and expertise.
+Cable Modem Monitor is an open-source project that provides a Home Assistant integration for monitoring cable modem statistics. It has a single maintainer; community contributors add modem support, fixes, and improvements.
 
 ## Roles and Responsibilities
 
@@ -205,6 +205,6 @@ This project would not be possible without:
 
 ---
 
-**Last Updated:** 2025-11-06
+**Last Updated:** 2026-07-23
 **Effective Date:** 2025-11-06
 **Maintainer:** @kwschulz

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -639,4 +639,5 @@ words:
   - redactions
   - timespan
   - typetracking
+  - unconfigured
   - unmappable

--- a/custom_components/cable_modem_monitor/button.py
+++ b/custom_components/cable_modem_monitor/button.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import functools
 import logging
 from collections import Counter
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.const import CONF_HOST, EntityCategory
@@ -42,7 +44,7 @@ from .const import (
     CONF_VARIANT,
     DOMAIN,
 )
-from .coordinator import CableModemConfigEntry
+from .coordinator import ActiveOperation, CableModemConfigEntry
 from .lib.utils import get_device_name
 from .services import async_request_modem_refresh
 
@@ -55,6 +57,47 @@ PARALLEL_UPDATES = 0
 _NOTIFY_RESTART = "cable_modem_restart"
 _NOTIFY_RESET = "cable_modem_reset"
 _NOTIFY_UPDATE = "cable_modem_update"
+
+
+# ------------------------------------------------------------------
+# Operation mutex
+# ------------------------------------------------------------------
+
+
+class OperationInProgressError(HomeAssistantError):
+    """Raised when a destructive button operation is already running."""
+
+    def __init__(self, active: ActiveOperation) -> None:
+        """Store which operation holds the mutex."""
+        super().__init__(f"operation '{active}' already in progress")
+        self.active: ActiveOperation = active
+
+
+class OperationUnavailableError(HomeAssistantError):
+    """Raised when runtime_data is gone; the entry is unloading."""
+
+
+@contextmanager
+def hold_active_operation(
+    entry: CableModemConfigEntry,
+    op: ActiveOperation,
+) -> Iterator[None]:
+    """Hold the destructive-operation mutex for the handler's duration."""
+    # See HA_ADAPTER_SPEC.md § Operation Mutex. Sync contextmanager on
+    # purpose: set/clear is synchronous, the body is where awaits happen.
+    runtime = entry.runtime_data
+    if runtime is None:
+        raise OperationUnavailableError("runtime_data unavailable; entry is unloading")
+    if runtime.active_operation is not None:
+        raise OperationInProgressError(runtime.active_operation)
+    runtime.active_operation = op
+    try:
+        yield
+    finally:
+        # Re-read; the entry may have unloaded or reloaded during the body.
+        runtime = entry.runtime_data
+        if runtime is not None:
+            runtime.active_operation = None
 
 
 # ------------------------------------------------------------------
@@ -155,37 +198,23 @@ class RestartModemButton(_ButtonBase):
         orchestrator = runtime.orchestrator
         model = runtime.modem_identity.model
 
-        # Refuse overlapping destructive operations. ``active_operation``
-        # is the only gate — no ``recovery_active`` check. A user who
-        # sees a flakey modem after a restart is allowed to retry once
-        # this press finishes; Core's recovery window doesn't block
-        # the button.
-        if runtime.active_operation is not None:
+        # No state writes in this handler: a ButtonEntity's state is its
+        # last-pressed timestamp, and every write during a press renders
+        # in the logbook as another "Pressed" entry attributed to the
+        # pressing user. The mutex alone refuses overlapping presses;
+        # no ``recovery_active`` check. A user who sees a flakey modem
+        # after a restart is allowed to retry once this press finishes.
+        try:
+            with hold_active_operation(self._entry, "restart"):
+                _LOGGER.info("Modem restart initiated [%s]", model)
+                result: RestartResult = await self.hass.async_add_executor_job(orchestrator.restart)
+        except OperationInProgressError as err:
             _LOGGER.warning(
                 "Operation '%s' already in progress [%s] — ignoring restart press",
-                runtime.active_operation,
+                err.active,
                 model,
             )
             return
-
-        _LOGGER.info("Modem restart initiated [%s]", model)
-
-        # Claim the mutex and mark the button busy. Clear both in
-        # finally so the button recovers even if restart raises.
-        runtime.active_operation = "restart"
-        self._attr_available = False
-        self.async_write_ha_state()
-
-        try:
-            result: RestartResult = await self.hass.async_add_executor_job(orchestrator.restart)
-        finally:
-            # Re-read runtime_data — the entry may have unloaded
-            # during the await. If unloaded, nothing to clear.
-            current_runtime = self._entry.runtime_data
-            if current_runtime is not None:
-                current_runtime.active_operation = None
-            self._attr_available = True
-            self.async_write_ha_state()
 
         if result.success:
             _LOGGER.info("Restart command sent [%s] in %.1fs", model, result.elapsed_seconds)
@@ -234,6 +263,16 @@ class UpdateModemDataButton(_ButtonBase):
         runtime = self._entry.runtime_data
         model = runtime.modem_identity.model
 
+        # Refuse while a destructive operation runs; never sets the
+        # mutex itself (a refresh is not destructive).
+        if runtime.active_operation is not None:
+            _LOGGER.warning(
+                "Operation '%s' already in progress [%s] — ignoring update press",
+                runtime.active_operation,
+                model,
+            )
+            return
+
         _LOGGER.info("Manual data update triggered [%s]", model)
 
         await async_request_modem_refresh(runtime)
@@ -262,6 +301,24 @@ class ResetEntitiesButton(_ButtonBase):
 
     async def async_press(self) -> None:
         """Handle button press — re-detect probes, remove entities, reload."""
+        model = self._entry.runtime_data.modem_identity.model
+
+        # A second press while the first is still tearing down entities
+        # would fire coordinator updates against unloaded entities
+        # (UC-80). Same no-state-writes rule as the restart button.
+        try:
+            with hold_active_operation(self._entry, "reset"):
+                await self._reset_entities(model)
+        except OperationInProgressError as err:
+            _LOGGER.warning(
+                "Operation '%s' already in progress [%s] — ignoring reset press",
+                err.active,
+                model,
+            )
+            return
+
+    async def _reset_entities(self, model: str) -> None:
+        """Re-detect probes, remove entities, reload, notify."""
         # Re-detect probe capabilities
         updated = await self._redetect_probes()
 
@@ -274,7 +331,6 @@ class ResetEntitiesButton(_ButtonBase):
         ]
         entities_to_remove = [entry.entity_id for entry in entries_to_remove]
 
-        model = self._entry.runtime_data.modem_identity.model
         # Breakdown by platform so the count reconciles with each
         # platform's own "Created N entities" log on re-init.
         breakdown = Counter(entry.domain for entry in entries_to_remove)

--- a/custom_components/cable_modem_monitor/const.py
+++ b/custom_components/cable_modem_monitor/const.py
@@ -8,7 +8,7 @@ from homeassistant.const import Platform
 
 # IMPORTANT: Do not edit VERSION manually!
 # Use: python scripts/release.py <version>
-VERSION = "3.14.0-beta.15"
+VERSION = "3.14.0-beta.16"
 
 DOMAIN = "cable_modem_monitor"
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON]

--- a/custom_components/cable_modem_monitor/docs/HA_ADAPTER_SPEC.md
+++ b/custom_components/cable_modem_monitor/docs/HA_ADAPTER_SPEC.md
@@ -37,7 +37,7 @@ Core, it should.
 | [Restart Lifecycle](#restart-lifecycle) | Button → executor → one-shot command → return |
 | [Recovery Adapter](#recovery-adapter) | Observer + cadence listener that reacts to Core's `recovery_active` flag |
 | [Operation Mutex](#operation-mutex) | `active_operation` field — mutex between destructive buttons (restart, reset) |
-| [Reset Entities Concurrency Guard](#reset-entities-concurrency-guard) | `active_operation` guard, `_attr_available` toggle, null-safety |
+| [Reset Entities Concurrency Guard](#reset-entities-concurrency-guard) | `active_operation` guard, null-safety |
 | [Reauth Flow](#reauth-flow) | Circuit breaker → `async_step_reauth` |
 | [Diagnostics Platform](#diagnostics-platform) | Core diagnostics + HA-side data |
 | [Services](#services) | `generate_dashboard`, `request_refresh`, `request_health_check` |
@@ -91,7 +91,9 @@ flag. The two answer different questions:
   recovery window? (True for the duration of
   `_RECOVERY_WINDOW_SECONDS` after any recovery trigger.)
 
-The button is disabled when *either* is set. During a button-press
+Only `active_operation` gates the buttons: a press while it is set
+is refused (logged, no dispatch). `recovery_active` never gates
+anything — it only drives polling cadence. During a button-press
 restart both are True briefly; after `restart()` returns,
 `active_operation` clears while `recovery_active` continues for
 the rest of the window.
@@ -506,7 +508,7 @@ the button itself does not observe the reboot.
 ```text
 User presses "Restart Modem"
  │
- ├─ 1. Acquire active_operation = "restart" via context manager
+ ├─ 1. Acquire active_operation = "restart" via hold_active_operation
  │     (refuses if another destructive operation is already running).
  │     No gate on recovery_active — a user who sees a flakey modem
  │     after a restart is allowed to try again.
@@ -515,21 +517,34 @@ User presses "Restart Modem"
  │     orchestrator.restart()
  │     (returns in 2–5 s; triggers a recovery window internally)
  │
- ├─ 3. Send persistent notification:
+ ├─ 3. Context manager exits → active_operation cleared. A new press
+ │     is accepted from here on; the user may retry if the dashboard
+ │     shows a flakey state.
+ │
+ ├─ 4. Send persistent notification:
  │     success → "Restart command sent"
  │     failure → "Restart command failed: <error>"
  │
- └─ 4. Context manager exits → active_operation cleared. Button is
-       immediately available again; the user may press it once more
-       if the dashboard shows a flakey state they want to retry.
+ └─ 5. Trigger one immediate data refresh so the dashboard reacts to
+       the post-dispatch state (typically UNREACHABLE while the modem
+       reboots). On failure, raise HomeAssistantError after the
+       refresh so the caller sees the action fail.
 ```
 
-The restart button returns its "busy" state after step 4. Scheduled
-data polls run at recovery cadence (driven by § Recovery Adapter)
-and surface actual modem state — UNREACHABLE while the modem is
-down, transitional docsis states while it ranges, ONLINE once it
-returns. The dashboard reflects truth throughout; no synthetic
-label.
+**No state writes during the press.** A `ButtonEntity`'s state is
+its last-pressed timestamp, and every state write during the press
+renders in the logbook as another "Pressed" entry attributed to the
+pressing user — the former `_attr_available` grey-out made one press
+log three times. The frontend already shows in-flight feedback while
+the press service call is pending; overlap protection is the
+`active_operation` mutex alone. This matches HA core convention: no
+core button platform writes state inside `async_press`.
+
+After step 5, scheduled data polls run at recovery cadence (driven
+by § Recovery Adapter) and surface actual modem state — UNREACHABLE
+while the modem is down, transitional docsis states while it ranges,
+ONLINE once it returns. The dashboard reflects truth throughout; no
+synthetic label.
 
 ### Sensor Behavior During a Recovery Window
 
@@ -543,7 +558,7 @@ observed outage, heuristic).
 | Health sensors (ICMP, HTTP, health_status) | Independent coordinator. Continue updating on their own cadence — probes naturally report UNRESPONSIVE while the modem is down and recover when the modem does. |
 | Data sensors (channel counts, SNR, power, uptime, system_info fields) | Available when the snapshot's `modem_data` is not None. Unavailable when `modem_data is None` (poll failed — typically UNREACHABLE during the reboot itself). This is the same rule as any non-recovery period; no recovery-specific special case. |
 | Per-channel sensors | Same as data sensors. |
-| Restart button | Disabled only while `active_operation == "restart"` (during the ~2–5 s command dispatch). After that it's clickable again — the user may choose to retry after observing the dashboard. |
+| Restart button | Always available (never greys out). A second press is refused only while `active_operation == "restart"` (during the ~2–5 s command dispatch). After that a press dispatches again — the user may choose to retry after observing the dashboard. |
 | Update Modem Data button | Press is refused when `active_operation` is set. Normal polling at recovery cadence already refreshes the dashboard; extra manual refreshes would be wasted. |
 | Reset Entities button | Press is refused when `active_operation` is set. |
 
@@ -726,7 +741,7 @@ Distinct from Core's `recovery_active`:
 | — (no active_operation) | restart | Allowed; `active_operation = "restart"` for the handler's duration (~2–5 s). |
 | — (no active_operation) | reset | Allowed; `active_operation = "reset"`. |
 | — (no active_operation) | refresh (user) | Allowed — runs normally. |
-| `active_operation` set | any button | Refused (button disabled in UI; direct invocation logs and returns). |
+| `active_operation` set | any button | Refused — the press logs a warning and returns without dispatching. |
 
 `recovery_active` has no row because it doesn't participate in
 gating. A button press during a recovery window is allowed; the
@@ -745,14 +760,14 @@ def hold_active_operation(
 ) -> Iterator[None]:
     runtime = entry.runtime_data
     if runtime is None:
-        raise OperationUnavailableError("runtime_data unavailable — entry is unloading")
+        raise OperationUnavailableError("runtime_data unavailable; entry is unloading")
     if runtime.active_operation is not None:
         raise OperationInProgressError(runtime.active_operation)
     runtime.active_operation = op
     try:
         yield
     finally:
-        # Re-read — entry may have unloaded during the body.
+        # Re-read; the entry may have unloaded or reloaded during the body.
         runtime = entry.runtime_data
         if runtime is not None:
             runtime.active_operation = None
@@ -814,39 +829,34 @@ still running can fire `_handle_coordinator_update()` against
 already-unloaded entities — observed symptom is an `AttributeError`
 on `entry.runtime_data` after the entry is partially torn down.
 
-The Reset button uses the shared `_hold_active_operation` context
-manager (see § Operation Mutex) for its mutex discipline. The
-button-specific availability toggle lives inside the `with` body:
+The Reset button uses the shared `hold_active_operation` context
+manager (see § Operation Mutex) for its mutex discipline. No state
+writes inside the handler — same logbook rule as § Restart
+Lifecycle:
 
 ```python
 async def async_press(self) -> None:
     try:
-        with _hold_active_operation(self._entry, "reset"):
-            self._attr_available = False
-            self.async_write_ha_state()
-            try:
-                # existing reset body — remove data-dependent entities,
-                # re-register deferred listener, trigger refresh
-                ...
-            finally:
-                self._attr_available = True
-                self.async_write_ha_state()
-    except OperationInProgressError:
+        with hold_active_operation(self._entry, "reset"):
+            # reset body — re-detect probes, remove entities,
+            # update config entry, reload, notify
+            ...
+    except OperationInProgressError as err:
+        _LOGGER.warning(...)
         return  # another destructive operation is running
 ```
 
-Three defences, all required:
+Two defences, both required:
 
 1. **`active_operation` check at entry** (via the context manager) —
    a second click while any destructive operation is running refuses
    immediately. The field lives on `RuntimeData`, not the button
    instance, so it survives the temporary teardown of data-dependent
    entities during reset.
-2. **`_attr_available = False` during the work** — the UI visibly
-   disables the button so the user isn't tempted to hammer it.
-3. **Null-safety** — the context manager re-reads `runtime_data` on
-   exit because `async_unload_entry` can fire concurrently and clear
-   it to `None`. The reset flow must not assume the entry is still
+2. **Null-safety** — the context manager re-reads `runtime_data` on
+   exit because `async_unload_entry` can fire concurrently (and the
+   reset body itself reloads the entry, replacing `runtime_data`).
+   The reset flow must not assume the entry it started with is still
    loaded when it returns.
 
 ---

--- a/custom_components/cable_modem_monitor/manifest.json
+++ b/custom_components/cable_modem_monitor/manifest.json
@@ -17,8 +17,8 @@
     "solentlabs.cable_modem_monitor_catalog"
   ],
   "requirements": [
-    "solentlabs-cable-modem-monitor-core==3.14.0-beta.15",
-    "solentlabs-cable-modem-monitor-catalog==3.14.0-beta.15"
+    "solentlabs-cable-modem-monitor-core==3.14.0-beta.16",
+    "solentlabs-cable-modem-monitor-catalog==3.14.0-beta.16"
   ],
-  "version": "3.14.0-beta.15"
+  "version": "3.14.0-beta.16"
 }

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -75,7 +75,7 @@ dashboard's Raw Configuration Editor as a starting point.
 The example uses 24 downstream channels (typical for DOCSIS 3.0). If
 your modem has fewer or more, add/remove channel entries following the
 existing pattern. Entity IDs follow the [Entity Naming Pattern in the
-README](../README.md#available-sensors).
+README](https://github.com/solentlabs/cable_modem_monitor#available-sensors).
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -322,7 +322,7 @@ See [ORCHESTRATION_SPEC.md § Logging Contract](../packages/cable_modem_monitor_
 
 **Symptoms:**
 
-- You see `sensor.cable_modem_upstream_channel_count` showing 4-8 channels
+- You see `sensor.cable_modem_us_channel_count` showing 4-8 channels
 - But individual upstream sensors (`US Ch X Power`, `US Ch X Frequency`) are missing
 - Only downstream sensors are created
 
@@ -513,12 +513,12 @@ Channel sensors include channel type for DOCSIS 3.1 compatibility:
 | Downstream SNR | `sensor.cable_modem_ds_qam_ch_32_snr` | DS QAM Ch 32 SNR |
 | Upstream ATDMA Power | `sensor.cable_modem_us_atdma_ch_3_power` | US ATDMA Ch 3 Power |
 | Upstream OFDMA Power | `sensor.cable_modem_us_ofdma_ch_1_power` | US OFDMA Ch 1 Power |
-| Channel Count | `sensor.cable_modem_downstream_channel_count` | DS Channel Count |
+| Channel Count | `sensor.cable_modem_ds_channel_count` | DS Channel Count |
 
 **Note:**
 
 - Entity IDs always include `cable_modem_` prefix
-- Channel type is included: `qam`, `ofdm`, `atdma`, `ofdma`
+- The examples show Channel ID mode, which includes the channel type: `qam`, `ofdm`, `atdma`, `ofdma`. Channel Number mode (the recommended default) omits it: `sensor.cable_modem_ds_ch_32_power`
 - DS = Downstream, US = Upstream
 
 ### DOCSIS Channel Types

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -19,10 +19,12 @@ Releases follow a PR-based workflow:
   `release.py` updates the version files only at release-prep time, so
   during development the manifest, startup banner, and downloaded
   diagnostics all report the previous tag's number (e.g. `beta.14`
-  while `beta.15` work is in flight, untagged). This is expected — the
-  version string is **not** evidence of which code is loaded. Confirm
-  loaded code by observable behavior (UI state, logs), never by the
-  reported version.
+  while `beta.15` work is in flight, untagged). This is expected. The
+  startup banner is still the tell: it appends `(local dev)` whenever
+  the `CMM_LOCAL_DEV` env var is set (`docker-compose.test.yml` sets
+  it for the local harness), so a dev-tree install self-identifies in
+  the log regardless of the version it reports. Whether a *specific*
+  change is live is confirmed by behavior, not the number.
 - **Never run `gh release create` manually.** Let CI handle it.
 - **Dogfood on local HA** before stable releases (maintainer launches,
   not automated).

--- a/docs/setup/GETTING_STARTED.md
+++ b/docs/setup/GETTING_STARTED.md
@@ -56,7 +56,7 @@ slower and breaks file watchers.
 
 ```bash
 make validate       # Ruff + Black + quick tests (~30s)
-make validate-ci    # Full ruff + pytest (2–5 min) — run before push
+make validate-ci    # Local CI mirror: lint, types, tests, regression (2-5 min); run before push
 make test           # All three test suites (Core, Catalog, HA)
 ```
 

--- a/packages/cable_modem_monitor_catalog/pyproject.toml
+++ b/packages/cable_modem_monitor_catalog/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solentlabs-cable-modem-monitor-catalog"
-version = "3.14.0-beta.15"
+version = "3.14.0-beta.16"
 description = "Cable Modem Monitor Catalog — modem config files and parser overrides"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "solentlabs-cable-modem-monitor-core==3.14.0-beta.15",
+    "solentlabs-cable-modem-monitor-core==3.14.0-beta.16",
 ]
 license = "MIT"
 authors = [

--- a/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/sercomm/dm1000/parser.yaml
+++ b/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/sercomm/dm1000/parser.yaml
@@ -75,6 +75,9 @@ upstream:
     - key: upstream
       field: channel_id
       type: integer
+      # Inactive slots report '---' for the channel id (alongside
+      # modulation QAM_NONE, which the filter below drops).
+      null_values: ["---"]
     - key: Freq
       field: frequency
       type: frequency

--- a/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/sercomm/dm1000/test_data/modem.expected.json
+++ b/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/sercomm/dm1000/test_data/modem.expected.json
@@ -457,6 +457,7 @@
     },
     {
       "channel_id": 0,
+      "channel_number": 5,
       "channel_type": "ofdma",
       "lock_status": "locked",
       "power": 58.391663

--- a/packages/cable_modem_monitor_catalog/tests/test_event_payload_conformance.py
+++ b/packages/cable_modem_monitor_catalog/tests/test_event_payload_conformance.py
@@ -1,0 +1,33 @@
+"""Every committed golden validates against the event bus payload schema.
+
+Regression net for #92: the DM1000 OFDMA hook appended a channel without
+``channel_number``. HAR replay passed (parser and golden agreed on the
+gap), but once the event payload shipped, ``ModemDataPayload.model_validate``
+crashed every poll. Goldens are parser output and the payload is fired
+from that output unconditionally, so a schema violation here is a
+runtime crash. Runs for every modem regardless of ``status``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from solentlabs.cable_modem_monitor_core.orchestration.event_payload import (
+    ModemDataPayload,
+)
+
+_MODEMS_ROOT = Path(__file__).parent.parent / "solentlabs" / "cable_modem_monitor_catalog" / "modems"
+_GOLDENS = sorted(_MODEMS_ROOT.rglob("test_data/*.expected.json"))
+
+
+def _golden_id(path: Path) -> str:
+    modem_dir = path.parent.parent
+    return f"{modem_dir.parent.name}/{modem_dir.name}/{path.name}"
+
+
+@pytest.mark.parametrize("golden_path", _GOLDENS, ids=_golden_id)
+def test_golden_validates_as_event_payload(golden_path: Path) -> None:
+    """Golden passes the same validation to_event_payload runs per poll."""
+    ModemDataPayload.model_validate(json.loads(golden_path.read_text()))

--- a/packages/cable_modem_monitor_core/docs/CHANNEL_IDENTIFICATION_SPEC.md
+++ b/packages/cable_modem_monitor_core/docs/CHANNEL_IDENTIFICATION_SPEC.md
@@ -524,6 +524,15 @@ The rule: map `channel_number` from modem-provided data when
 available; auto-assign from position when not. Either way, every
 channel in Core's output MUST have a `channel_number`.
 
+The format-level auto-assign runs before parser.py hooks, so the
+coordinator applies a final numbering pass after hooks: any channel
+still lacking `channel_number` (hook-appended, or hook-built for a
+section with no parser.yaml config) is assigned its 1-based position
+in the final list. Mapped or format-assigned numbers are never
+overwritten. This closes the gap where a hook-appended channel
+shipped without the field and failed event payload validation on
+every poll (#92, DM1000 OFDMA).
+
 See PARSING_SPEC.md § Field Guarantees for the output guarantee.
 
 ### Modules affected

--- a/packages/cable_modem_monitor_core/docs/FORMAT_JSON_SPEC.md
+++ b/packages/cable_modem_monitor_core/docs/FORMAT_JSON_SPEC.md
@@ -94,10 +94,21 @@ upstream:
 | `array_path` | string | yes* | Dot-notation path to the channel array |
 | `fields` | list | yes* | Key-to-field mappings within each JSON object |
 | `fields[].key` | string | yes | JSON key name in the source object |
+| `fields[].field` | string | yes | Canonical channel field name (FIELD_REGISTRY.md) |
+| `fields[].type` | string | yes | Field type (one of `FIELD_TYPES`) |
 | `fields[].fallback_key` | string | no | Alternative key if primary is missing |
 | `fields[].format` | string | no | Input format for types that require it (e.g., `seconds` for `uptime`). |
 | `fields[].scale` | number | no | Multiplier applied after type conversion. Whole-number results cast to int. |
+| `fields[].unit` | string | no | Unit suffix stripped (case-insensitive) from the raw text before conversion (e.g. `"3.2 dBmV"` yields `3.2`). |
+| `fields[].map` | map | no | Exact-match value translation on the stripped raw text before type conversion (e.g. `{"Locked": "locked"}`); unmapped values pass through unchanged. |
+| `fields[].truthy` | any | no | Declares the raw value meaning true; the field becomes the boolean `raw == truthy`, bypassing type conversion. |
+| `fields[].separator` | string | no | Splits a compound string value on a delimiter before conversion (e.g. `"0.3/60.3"`). |
+| `fields[].separator_index` | integer | no | Which split segment to convert (default 0 = first; out-of-range falls back to the unsplit value). |
+| `fields[].range` | string | no | `span` only: emits `last - first` from the separator-split parts (band-edge string to `channel_width`). Requires `separator`. Values not carrying the separator skip silently (mixed SC-QAM/OFDM arrays sharing a key). |
+| `fields[].null_values` | list | no | Firmware no-value sentinels (e.g. `"---"` on inactive channel slots). Matching raw values (compared whitespace-trimmed) skip silently as sparse data; the cannot-coerce WARN stays reserved for undeclared shapes. |
+| `channel_type` | object | no | `fixed:`, per-row `field:` + `map:`, or `derive:` form (same semantics as other formats). Applied before `fixed_fields`; rows that already extracted a `channel_type` keep it. |
 | `fixed_fields` | map | no | Static field values for every channel. Applied after channel_type, before filter (same semantics as XML tables). |
+| `filter` | object | no | Keep/drop rules on converted field values: a plain value keeps only matching channels; `{not: value}` drops matching channels. Applied after `fixed_fields`. |
 | `arrays` | list | yes* | Multi-array form (alternative to array_path/fields) |
 
 \* Mutually exclusive: use either flat form (`array_path` + `fields`)

--- a/packages/cable_modem_monitor_core/docs/ORCHESTRATION_USE_CASES.md
+++ b/packages/cable_modem_monitor_core/docs/ORCHESTRATION_USE_CASES.md
@@ -1323,7 +1323,7 @@ sequenceDiagram
         Note over O: Returns in 2–5s
         O-->>C: RestartResult
         C->>U: Persistent notification — "Restart command sent"
-        C->>C: active_operation cleared; button re-enabled
+        C->>C: active_operation cleared; new presses accepted
         Note over O: recovery_active is True; observer fired
         Note over C: Adapter switches coordinator to recovery cadence
     end
@@ -1331,14 +1331,16 @@ sequenceDiagram
 
 **Assertions:**
 
-- Restart button is disabled only while `active_operation` is held
-  (~2–5 s). It is NOT gated on `recovery_active` — the user may
-  retry after observing the dashboard.
+- A second restart press is refused only while `active_operation`
+  is held (~2–5 s). The button never greys out and is NOT gated on
+  `recovery_active` — the user may retry after observing the
+  dashboard.
 - `restart()` runs in a thread (keeps HA's event loop free) but
   returns quickly
 - User notified that the command was sent — not that it succeeded
-- No "immediate data refresh after restart" — the recovery window
-  handles that by polling at a faster cadence
+- The consumer triggers one immediate data refresh after dispatch so
+  its dashboard reflects the post-dispatch state; beyond that, the
+  recovery window handles updates by polling at a faster cadence
 - The dashboard reflects real modem state throughout (Unreachable,
   transitional, Operational) — no synthetic label
 
@@ -1517,7 +1519,7 @@ sequenceDiagram
   recovery state.
 - Core does not push extra updates during recovery. The coordinator
   just polls faster; each poll drives its own update.
-- Restart button is disabled only for the duration of the
+- Restart presses are refused only for the duration of the
   `active_operation` mutex (~2–5 s per press). A user who observes
   a flakey modem mid-window may re-press restart; see UC-42.
 - Snapshots during ranging may report reduced channel bonding

--- a/packages/cable_modem_monitor_core/pyproject.toml
+++ b/packages/cable_modem_monitor_core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solentlabs-cable-modem-monitor-core"
-version = "3.14.0-beta.15"
+version = "3.14.0-beta.16"
 description = "Cable Modem Monitor Core — platform-agnostic DOCSIS monitoring engine"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/models/parser_config/common.py
+++ b/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/models/parser_config/common.py
@@ -101,6 +101,11 @@ class JsonChannelMapping(BaseModel):
     instead of a positional pick. ``range: span`` computes
     ``last - first`` (used to derive ``channel_width`` from a band-edge
     range like ``"751~860"``). Requires ``separator`` to be set.
+
+    ``null_values`` declares firmware no-value sentinels (e.g. ``"---"``
+    on inactive channel slots). Matching raw values are skipped silently
+    as sparse data instead of raising the cannot-coerce WARN, which
+    stays reserved for genuinely novel shapes.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -116,6 +121,7 @@ class JsonChannelMapping(BaseModel):
     separator_index: int = 0
     range: Literal["span"] | None = None
     scale: int | float | None = None
+    null_values: list[str] = []
 
     @model_validator(mode="after")
     def validate_field_type(self) -> JsonChannelMapping:

--- a/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/parsers/coordinator.py
+++ b/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/parsers/coordinator.py
@@ -144,18 +144,30 @@ class ModemParserCoordinator:
         """
         section = getattr(self._config, section_name, None)
         if section is None:
-            return self._apply_hook(section_name, [], resources), AnchorCount(), None
+            channels: list[dict[str, Any]] = []
+            anchors = AnchorCount()
+            resource_path: str | None = None
+        else:
+            parser_fn = CHANNEL_PARSERS.get(type(section))
+            if parser_fn is None:
+                raise NotImplementedError(f"{type(section).__name__} has no registered channel parser")
 
-        parser_fn = CHANNEL_PARSERS.get(type(section))
-        if parser_fn is None:
-            raise NotImplementedError(f"{type(section).__name__} has no registered channel parser")
+            channels, anchors = parser_fn(section, resources)
+            # HNAP and arrays-mode JSON sections lack a single section-level
+            # `resource` — they don't participate in per-resource stub
+            # detection (the wrapper already aggregates per-array internally).
+            resource_path = getattr(section, "resource", None) or None
 
-        channels, anchors = parser_fn(section, resources)
-        # HNAP and arrays-mode JSON sections lack a single section-level
-        # `resource` — they don't participate in per-resource stub
-        # detection (the wrapper already aggregates per-array internally).
-        resource_path = getattr(section, "resource", None) or None
-        return self._apply_hook(section_name, channels, resources), anchors, resource_path
+        channels = self._apply_hook(section_name, channels, resources)
+        # Post-hook numbering: format parsers auto-assign before hooks
+        # run, so channels a hook appends (or builds for an unconfigured
+        # section) would otherwise ship without the channel_number every
+        # channel MUST carry. See CHANNEL_IDENTIFICATION_SPEC §10.
+        if isinstance(channels, list):
+            for idx, channel in enumerate(channels, start=1):
+                if "channel_number" not in channel:
+                    channel["channel_number"] = idx
+        return channels, anchors, resource_path
 
     def _extract_system_info(
         self,

--- a/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/parsers/formats/json_parser.py
+++ b/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/parsers/formats/json_parser.py
@@ -197,11 +197,12 @@ def _extract_channel(
     Tries the primary ``key`` first, then ``fallback_key`` if present.
     Returns ``None`` if no fields could be extracted.
 
-    Raw values that are absent or whitespace-only are silently skipped
-    (sparse-data signal). Non-empty raw values that fail to coerce —
-    after any declared ``separator``/``range_op`` transform — surface
-    as WARN logs so catalog gaps don't go unnoticed when firmware
-    introduces a novel shape.
+    Raw values that are absent, whitespace-only, or listed in the
+    mapping's ``null_values`` are silently skipped (sparse-data
+    signal). Non-empty raw values that fail to coerce — after any
+    declared ``separator``/``range_op`` transform — surface as WARN
+    logs so catalog gaps don't go unnoticed when firmware introduces
+    a novel shape.
     """
     channel: dict[str, Any] = {}
 
@@ -215,6 +216,11 @@ def _extract_channel(
         if original_raw is None:
             continue
         if isinstance(original_raw, str) and not original_raw.strip():
+            continue
+        # Declared no-value sentinels are sparse data, same as absent or
+        # whitespace-only; the cannot-coerce WARN below stays reserved
+        # for shapes the catalog has not seen.
+        if isinstance(original_raw, str) and original_raw.strip() in mapping.null_values:
             continue
 
         # Boolean truthy check: compare against declared truthy value

--- a/packages/cable_modem_monitor_core/tests/fixtures/pipeline/golden_hnap_2ch.json
+++ b/packages/cable_modem_monitor_core/tests/fixtures/pipeline/golden_hnap_2ch.json
@@ -1,7 +1,7 @@
 {
   "downstream": [
-    {"channel_id": 1, "frequency": 507000000, "power": 2.5},
-    {"channel_id": 2, "frequency": 513000000, "power": 2.6}
+    {"channel_id": 1, "channel_number": 1, "frequency": 507000000, "power": 2.5},
+    {"channel_id": 2, "channel_number": 2, "frequency": 513000000, "power": 2.6}
   ],
   "upstream": [],
   "system_info": {

--- a/packages/cable_modem_monitor_core/tests/parsers/fixtures/coordinator/valid/json_derive_channel_type.json
+++ b/packages/cable_modem_monitor_core/tests/parsers/fixtures/coordinator/valid/json_derive_channel_type.json
@@ -1,0 +1,55 @@
+{
+  "_description": "Coordinator applies channel_type derive:from_modulation direction-aware (qam/atdma vs ofdm/ofdma); generic OFDM modulation labels feed derivation, then strip",
+  "_json": {
+    "/api/downstream": {
+      "channels": [
+        {"id": 1, "mod": "QAM256", "freq": 507000000},
+        {"id": 33, "mod": "OFDM PLC", "freq": 850000000}
+      ]
+    },
+    "/api/upstream": {
+      "channels": [
+        {"id": 4, "mod": "QAM64", "freq": 25900000},
+        {"id": 9, "mod": "OFDMA", "freq": 36000000}
+      ]
+    }
+  },
+  "_parser_config": {
+    "downstream": {
+      "format": "json",
+      "resource": "/api/downstream",
+      "array_path": "channels",
+      "fields": [
+        {"key": "id", "field": "channel_id", "type": "integer"},
+        {"key": "mod", "field": "modulation", "type": "modulation"},
+        {"key": "freq", "field": "frequency", "type": "frequency", "unit": "Hz"}
+      ],
+      "channel_type": {"derive": "from_modulation"}
+    },
+    "upstream": {
+      "format": "json",
+      "resource": "/api/upstream",
+      "array_path": "channels",
+      "fields": [
+        {"key": "id", "field": "channel_id", "type": "integer"},
+        {"key": "mod", "field": "modulation", "type": "modulation"},
+        {"key": "freq", "field": "frequency", "type": "frequency", "unit": "Hz"}
+      ],
+      "channel_type": {"derive": "from_modulation"}
+    }
+  },
+  "_expected": {
+    "downstream": [
+      {"channel_id": 1, "channel_number": 1, "channel_type": "qam", "modulation": "QAM256", "frequency": 507000000},
+      {"channel_id": 33, "channel_number": 2, "channel_type": "ofdm", "frequency": 850000000}
+    ],
+    "upstream": [
+      {"channel_id": 4, "channel_number": 1, "channel_type": "atdma", "modulation": "QAM64", "frequency": 25900000},
+      {"channel_id": 9, "channel_number": 2, "channel_type": "ofdma", "frequency": 36000000}
+    ],
+    "system_info": {
+      "downstream_channel_count": 2,
+      "upstream_channel_count": 2
+    }
+  }
+}

--- a/packages/cable_modem_monitor_core/tests/parsers/fixtures/json_parser/valid/null_values_scoped_per_mapping.json
+++ b/packages/cable_modem_monitor_core/tests/parsers/fixtures/json_parser/valid/null_values_scoped_per_mapping.json
@@ -1,0 +1,16 @@
+{
+  "_description": "null_values is per-mapping; undeclared uncoercible shapes on other fields still WARN",
+  "_json": {"channels": [{"id": "---", "snr": "n/a"}]},
+  "_resource": "/api/data",
+  "_config": {
+    "format": "json",
+    "resource": "/api/data",
+    "array_path": "channels",
+    "fields": [
+      {"key": "id", "field": "channel_id", "type": "integer", "null_values": ["---"]},
+      {"key": "snr", "field": "snr", "type": "float"}
+    ]
+  },
+  "_expected": [],
+  "_expected_warnings": ["n/a"]
+}

--- a/packages/cable_modem_monitor_core/tests/parsers/fixtures/json_parser/valid/null_values_sentinel_skips.json
+++ b/packages/cable_modem_monitor_core/tests/parsers/fixtures/json_parser/valid/null_values_sentinel_skips.json
@@ -1,0 +1,23 @@
+{
+  "_description": "Declared no-value sentinels skip silently as sparse data; no WARN, row survives with its other fields",
+  "_json": {"channels": [
+    {"id": "---", "freq": "507000000", "power": "3.1"},
+    {"id": "7", "freq": "513000000", "power": "2.9"}
+  ]},
+  "_resource": "/api/data",
+  "_config": {
+    "format": "json",
+    "resource": "/api/data",
+    "array_path": "channels",
+    "fields": [
+      {"key": "id", "field": "channel_id", "type": "integer", "null_values": ["---"]},
+      {"key": "freq", "field": "frequency", "type": "frequency", "unit": "Hz"},
+      {"key": "power", "field": "power", "type": "float"}
+    ]
+  },
+  "_expected": [
+    {"frequency": 507000000, "power": 3.1},
+    {"channel_id": 7, "frequency": 513000000, "power": 2.9}
+  ],
+  "_expected_warnings": []
+}

--- a/packages/cable_modem_monitor_core/tests/parsers/test_coordinator.py
+++ b/packages/cable_modem_monitor_core/tests/parsers/test_coordinator.py
@@ -174,6 +174,26 @@ class _ReplacingPostProcessor:
         return [{"channel_id": 99, "channel_type": "qam", "custom": True}]
 
 
+class _AppendingPostProcessor:
+    """Post-processor that appends a channel without channel_number (issue #92 pattern)."""
+
+    def parse_downstream(self, channels: list[dict[str, Any]], resources: dict[str, Any]) -> list[dict[str, Any]]:
+        """Append a hook-built channel, as the DM1000 OFDMA hook does."""
+        channels.append({"channel_id": 0, "channel_type": "ofdma", "lock_status": "locked"})
+        return channels
+
+
+class _UpstreamHookOnlyPostProcessor:
+    """Post-processor supplying upstream channels for a section with no parser.yaml config."""
+
+    def parse_upstream(self, channels: list[dict[str, Any]], resources: dict[str, Any]) -> list[dict[str, Any]]:
+        """Return hook-built channels for an unconfigured section."""
+        return [
+            {"channel_id": 4, "channel_type": "ofdma", "lock_status": "locked"},
+            {"channel_id": 5, "channel_type": "ofdma", "lock_status": "locked"},
+        ]
+
+
 class TestPostProcessorHooks:
     """Tests for parser.py post-processing hook invocation."""
 
@@ -199,7 +219,9 @@ class TestPostProcessorHooks:
         coordinator = ModemParserCoordinator(config, _ReplacingPostProcessor())
         result, _ = coordinator.parse(resources)
 
-        assert result["downstream"] == [{"channel_id": 99, "channel_type": "qam", "custom": True}]
+        # channel_number is coordinator-assigned post-hook; replacement
+        # output is subject to the same numbering as any other channel.
+        assert result["downstream"] == [{"channel_id": 99, "channel_type": "qam", "custom": True, "channel_number": 1}]
 
     def test_no_hook_for_section(self) -> None:
         """Section without a hook uses BaseParser output as-is."""
@@ -228,6 +250,31 @@ class TestPostProcessorHooks:
         assert result["system_info"]["custom_key"] == "custom_value"
         assert result["system_info"]["downstream_channel_count"] == 1
         assert result["system_info"]["upstream_channel_count"] == 0
+
+    def test_hook_appended_channel_gets_channel_number(self, ds_fixture: dict[str, Any]) -> None:
+        """Channels appended by a hook are numbered by final list position.
+
+        CHANNEL_IDENTIFICATION_SPEC §10: every channel in Core's output
+        MUST have a channel_number. Format parsers number before hooks
+        run, so the coordinator numbers whatever the hook added.
+        """
+        resources = _build_resources(ds_fixture["_html"])
+        config = ParserConfig.model_validate(ds_fixture["_parser_config"])
+        coordinator = ModemParserCoordinator(config, _AppendingPostProcessor())
+        result, _ = coordinator.parse(resources)
+
+        assert result["downstream"][0]["channel_number"] == 1
+        assert result["downstream"][1]["channel_number"] == 2
+
+    def test_hook_only_section_gets_channel_numbers(self, ds_fixture: dict[str, Any]) -> None:
+        """Hook-supplied channels for an unconfigured section are numbered."""
+        resources = _build_resources(ds_fixture["_html"])
+        config = ParserConfig.model_validate(ds_fixture["_parser_config"])
+        # Config declares downstream only; the hook supplies upstream.
+        coordinator = ModemParserCoordinator(config, _UpstreamHookOnlyPostProcessor())
+        result, _ = coordinator.parse(resources)
+
+        assert [ch["channel_number"] for ch in result["upstream"]] == [1, 2]
 
     def test_no_post_processor(self, ds_fixture: dict[str, Any]) -> None:
         """Coordinator with no post-processor uses BaseParser output."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     # Runtime dependencies
     "requests>=2.34.2",   # HTTP client for modem polling
     "pydantic>=2.0",      # Data validation and modeling
-    "har-capture~=0.10.2", # HAR sanitization + PII validation; library API (custom_patterns kwarg) used in catalog scripts
+    "har-capture~=0.10.3", # HAR sanitization + PII validation; library API (custom_patterns kwarg) used in catalog scripts; 0.10.3 floor closes the pws credential-leak gap
 ]
 
 [project.optional-dependencies]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -49,5 +49,5 @@ defusedxml>=0.7.1                           # Safer XML parsing
 # -------------------------------
 # 🧪 Additional testing utilities
 # -------------------------------
-freezegun>=1.5.0                            # Time-freezing for deterministic tests
+freezegun>=1.5.0                            # Time-freezing for deterministic tests; pinned by pytest-homeassistant-custom-component
 responses>=0.26.0                           # Mock HTTP responses

--- a/tests/components/test_button.py
+++ b/tests/components/test_button.py
@@ -133,6 +133,26 @@ async def test_update_button_press_no_health(
     mock_data_coordinator.async_request_refresh.assert_awaited_once()
 
 
+async def test_update_button_refuses_when_operation_in_progress(
+    mock_orchestrator: MagicMock,
+    mock_data_coordinator: MagicMock,
+    mock_runtime_data: CableModemRuntimeData,
+):
+    """Update press is refused while a destructive operation runs."""
+    mock_runtime_data.active_operation = "restart"
+    entry = _make_entry(mock_runtime_data)
+    button = UpdateModemDataButton(entry)
+    button.hass = MagicMock()
+    mock_data_coordinator.async_request_refresh = AsyncMock()
+
+    await button.async_press()
+
+    mock_orchestrator.reset_connectivity.assert_not_called()
+    mock_data_coordinator.async_request_refresh.assert_not_awaited()
+    # Mutex value is unchanged — the update button never sets it.
+    assert mock_runtime_data.active_operation == "restart"
+
+
 # -----------------------------------------------------------------------
 # RestartModemButton
 # -----------------------------------------------------------------------
@@ -205,11 +225,16 @@ async def test_restart_button_press_failure(
     mock_data_coordinator.async_request_refresh.assert_awaited()
 
 
-async def test_restart_button_unavailable_during_dispatch(
+async def test_restart_button_no_state_writes_during_dispatch(
     mock_data_coordinator: MagicMock,
     mock_runtime_data: CableModemRuntimeData,
 ):
-    """Button shows unavailable in HA during command dispatch, available after."""
+    """Button stays available and writes no state during dispatch.
+
+    Any state write during a press renders in the logbook as another
+    "Pressed" entry attributed to the pressing user; one press must
+    produce exactly one entry.
+    """
     entry = _make_entry(mock_runtime_data)
     button = RestartModemButton(entry)
     button.hass = MagicMock()
@@ -231,19 +256,18 @@ async def test_restart_button_unavailable_during_dispatch(
 
     await button.async_press()
 
-    # During dispatch: unavailable
-    assert available_during_restart == [False]
-    # After dispatch: available again
+    # Available throughout — overlap protection is the mutex alone.
+    assert available_during_restart == [True]
     assert button._attr_available is True
-    # State pushed to HA twice (before + after)
-    assert button.async_write_ha_state.call_count == 2
+    # No state writes from the handler.
+    assert button.async_write_ha_state.call_count == 0
 
 
-async def test_restart_button_available_restored_on_exception(
+async def test_restart_button_no_state_writes_on_exception(
     mock_data_coordinator: MagicMock,
     mock_runtime_data: CableModemRuntimeData,
 ):
-    """Button restores availability even when restart raises."""
+    """Button stays available and writes no state when restart raises."""
     entry = _make_entry(mock_runtime_data)
     button = RestartModemButton(entry)
     button.hass = MagicMock()
@@ -257,9 +281,8 @@ async def test_restart_button_available_restored_on_exception(
     with pytest.raises(ConnectionError):
         await button.async_press()
 
-    # finally block restores availability
     assert button._attr_available is True
-    assert button.async_write_ha_state.call_count == 2
+    assert button.async_write_ha_state.call_count == 0
 
 
 async def test_restart_button_sets_and_clears_active_operation(
@@ -309,6 +332,38 @@ async def test_restart_button_clears_active_operation_on_exception(
         await button.async_press()
 
     assert mock_runtime_data.active_operation is None
+
+
+async def test_restart_button_tolerates_unload_during_dispatch(
+    mock_data_coordinator: MagicMock,
+    mock_runtime_data: CableModemRuntimeData,
+):
+    """Mutex cleanup tolerates runtime_data going None mid-dispatch.
+
+    Pins the second of the two defences in HA_ADAPTER_SPEC § Reset
+    Entities Concurrency Guard: the context manager re-reads
+    runtime_data on exit and must not raise when a concurrent unload
+    cleared it.
+    """
+    entry = _make_entry(mock_runtime_data)
+    button = RestartModemButton(entry)
+    button.hass = MagicMock()
+    button.hass.services.async_call = AsyncMock()
+    mock_data_coordinator.async_request_refresh = AsyncMock()
+
+    async def _unload_during_dispatch(*args, **kwargs):
+        entry.runtime_data = None
+        return RestartResult(success=True, elapsed_seconds=2.0)
+
+    button.hass.async_add_executor_job = AsyncMock(side_effect=_unload_during_dispatch)
+
+    await button.async_press()
+
+    # The orphaned runtime is left untouched — there was nothing to
+    # clear on the entry — and the handler still completes normally.
+    assert mock_runtime_data.active_operation == "restart"
+    button.hass.services.async_call.assert_awaited()
+    mock_data_coordinator.async_request_refresh.assert_awaited_once()
 
 
 async def test_restart_button_refuses_when_operation_in_progress(
@@ -433,6 +488,93 @@ async def test_reset_button_press_probes_failed(
 
     # Still reloads
     button.hass.config_entries.async_reload.assert_awaited_once()
+
+
+async def test_reset_button_sets_and_clears_active_operation(
+    mock_runtime_data: CableModemRuntimeData,
+):
+    """Reset press holds the mutex for the handler and clears it on exit."""
+    entry = _make_entry(mock_runtime_data)
+    button = ResetEntitiesButton(entry)
+    button.hass = MagicMock()
+    button.hass.services.async_call = AsyncMock()
+    button.hass.config_entries.async_update_entry = MagicMock()
+
+    observed_during_press: list[str | None] = []
+
+    async def _capture_reload(entry_id):
+        observed_during_press.append(mock_runtime_data.active_operation)
+
+    button.hass.config_entries.async_reload = AsyncMock(side_effect=_capture_reload)
+
+    mock_entity_reg = MagicMock()
+    mock_entity_reg.entities.values.return_value = []
+
+    assert mock_runtime_data.active_operation is None
+
+    with (
+        patch(
+            "custom_components.cable_modem_monitor.button.er.async_get",
+            return_value=mock_entity_reg,
+        ),
+        patch.object(button, "_redetect_probes", new=AsyncMock(return_value=None)),
+    ):
+        await button.async_press()
+
+    # Mutex was held during the reload...
+    assert observed_during_press == ["reset"]
+    # ...and cleared on exit.
+    assert mock_runtime_data.active_operation is None
+
+
+async def test_reset_button_refuses_when_operation_in_progress(
+    mock_runtime_data: CableModemRuntimeData,
+):
+    """A reset press while a restart is running is refused."""
+    mock_runtime_data.active_operation = "restart"
+    entry = _make_entry(mock_runtime_data)
+    button = ResetEntitiesButton(entry)
+    button.hass = MagicMock()
+    button.hass.config_entries.async_reload = AsyncMock()
+
+    redetect = AsyncMock()
+    with patch.object(button, "_redetect_probes", new=redetect):
+        await button.async_press()
+
+    # Handler returned early — nothing ran.
+    redetect.assert_not_awaited()
+    button.hass.config_entries.async_reload.assert_not_awaited()
+    # Mutex value is unchanged.
+    assert mock_runtime_data.active_operation == "restart"
+
+
+async def test_reset_button_clears_active_operation_on_exception(
+    mock_runtime_data: CableModemRuntimeData,
+):
+    """active_operation is cleared even when the reset body raises."""
+    entry = _make_entry(mock_runtime_data)
+    button = ResetEntitiesButton(entry)
+    button.hass = MagicMock()
+    button.hass.services.async_call = AsyncMock()
+    button.hass.config_entries.async_update_entry = MagicMock()
+    button.hass.config_entries.async_reload = AsyncMock(
+        side_effect=RuntimeError("reload failed"),
+    )
+
+    mock_entity_reg = MagicMock()
+    mock_entity_reg.entities.values.return_value = []
+
+    with (
+        patch(
+            "custom_components.cable_modem_monitor.button.er.async_get",
+            return_value=mock_entity_reg,
+        ),
+        patch.object(button, "_redetect_probes", new=AsyncMock(return_value=None)),
+        pytest.raises(RuntimeError),
+    ):
+        await button.async_press()
+
+    assert mock_runtime_data.active_operation is None
 
 
 async def test_redetect_probes_success(

--- a/tests/components/test_version_and_startup.py
+++ b/tests/components/test_version_and_startup.py
@@ -22,7 +22,7 @@ class TestVersion:
         Use: python scripts/release.py <version>
         The script updates const.py, manifest.json, and this file.
         """
-        assert VERSION == "3.14.0-beta.15"
+        assert VERSION == "3.14.0-beta.16"
 
     def test_startup_log_message_format(self):
         """The startup log line includes the version string."""


### PR DESCRIPTION
Beta release **v3.14.0-beta.16**. Bumps all three packages in lock-step (HACS zip + Core + Catalog) so the Core and Catalog changes below reach users through the manifest `==` pin.

## Added

- `null_values` parser.yaml option: JSON field mappings can declare firmware no-value sentinels, which skip silently as sparse data while undeclared shapes keep their warning. The DM1000 declares `---` for its inactive upstream slots, removing four warning lines per poll (Related to #92)

## Changed

- har-capture floor raised to 0.10.3; the 0.10.3 sanitizer closes a credential-leak gap (the Sercomm `pws` login field) found during the DM1000 intake (Related to #92)

## Fixed

- DM1000 polling failed on every cycle since beta.10: channels built by parser.py hooks (the DM1000 OFDMA upstream) missed Core's channel_number pass and failed event payload validation, leaving all entities unavailable. Core now numbers hook-built channels after hooks run, and a new fleet test validates every catalog golden against the event payload schema so this class of gap fails CI instead of production polls (Related to #92)
- One button press, one logbook entry: the restart button's availability toggle wrote state during the press, so a single press rendered as three "Pressed" logbook entries. All three buttons now share the operation mutex the adapter spec defines; Reset Entities gains the double-click guard it was missing, and Update Modem Data refuses presses during destructive operations

Full detail in the `[3.14.0-beta.16]` CHANGELOG section. Beta prerelease, installs manually via the HACS version picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKi81ULCVP1mzpNntQChdB
