### PR TITLE
feat: v3.14.0 - the stable cut of the rebuilt modem engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.14.0] - 2026-08-28
+
 ### Overview
 
 The stable release of the v3.14 line, after more than three months in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,112 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Overview
+
+The stable release of the v3.14 line, after more than three months in
+public beta.
+
+**v3.14 rebuilds the modem engine from the ground up.** In v3.13, 19 of
+the 21 supported modems each carried a hand-written Python parser inside
+the integration. All 40 catalog entries are now described declaratively
+in YAML instead, two of them adding a small post-processor hook for
+firmware quirks the declarative layer cannot yet express. The parsing,
+authentication, and orchestration those descriptions drive live in a
+standalone library that Home Assistant is one consumer of, and the
+integration itself became an adapter over that engine. None of this asks
+you to start over. Config entries, entity IDs, history, and automations
+all carry forward.
+
+Per-beta detail is kept below, each beta under its own heading.
+
+### Upgrade Notes
+
+**Coming from v3.13.1.** Upgrade in place. The config entry migrates
+automatically: entity IDs, history, and automations are preserved, the
+entities and buttons v3.14 retired are cleaned up for you, and the two
+modems whose catalog entry was renamed during the beta run resolve to
+their new location on their own. Two things to know:
+
+- **Regenerate your dashboard** with the `generate_dashboard` service.
+  Sensors that used to have their own cards are now attribute rows or
+  have been retired, so a dashboard built on v3.13 will show gaps.
+- **You are also receiving the v3.13.2 changes.** That section exists in
+  this file but was never tagged or released, so its HNAP session reuse,
+  CM1200 HTTPS support, and firmware lockout detection reach stable
+  installs for the first time here.
+
+**Coming from a v3.14 beta.** Most testers need one action: press the
+**Reset Entities** button on the integration's device page. Sensors
+retired during the beta run (Docsis Status, System Uptime, Current Time)
+linger as unavailable until the entity registry is rebuilt. Reset
+Entities rebuilds it while keeping your config, history, and automations
+intact. Prefer it to removing the integration.
+
+Three cases need more than that, all of them narrow:
+
+- **Arris SB8200 entries on the `v7` or URL Token (body-token)
+  variant.** Both variant files were renamed mid-beta, `v7` in beta.6
+  and body-token in beta.12, and neither rename shipped a config-entry
+  migration. Remove and re-add once. Host and entity prefix are
+  unchanged, so history carries over.
+- **Arris G54 and Virgin Media Hub 5 entries created on a beta before
+  beta.13.** Both moved catalog location, to `commscope/g54` and
+  `sagemcom/f3896lg-vmb`. Remove and re-add once.
+- **Provisioned speed sensors created before beta.19** keep displaying
+  bit/s. Change the unit in the entity's own settings; installs that
+  create these sensors fresh get Mbit/s automatically.
+
+If you do remove and re-add an integration, the `orphaned_statistics`
+service reports long-term statistics left behind by the old entities.
+
+**If something looks wrong after upgrading, press Reset Entities
+first.** Removing and re-adding the integration is the last resort
+rather than the first step: it issues a new config entry ID, and every
+entity's unique ID is derived from it.
+
+### Highlights since v3.13.1
+
+- **The catalog grew from 21 entries to 40**, 28 of them confirmed
+  against real hardware. New this cycle: the Technicolor XB6, XB8 and
+  XB10, the Ziggo Sagemcom F3896LG, the Sercomm DM1000, the Hitron
+  CODA56, the Arris SB6183 and TG3442DE, the Netgear CM1100, CM2050V
+  and CM3000, and the Compal CH7465MT, among others.
+- **Authentication became data-driven.** Bearer tokens, PBKDF2 and
+  nonce and SJCL form logins, URL-token variants, per-action auth, and
+  credential-cookie injection are now catalog-selected strategies rather
+  than per-modem code.
+- **Login failures say what actually failed.** A busy modem, a login
+  endpoint returning 404, a firmware lockout, and a refused data page
+  each used to report rejected credentials. Each now reports its own
+  cause, and auth failures emit a single sanitized log line carrying the
+  modem's real response with the password redacted.
+- **Recovery is one concept.** A recovery state machine owns the
+  post-disruption polling window, entered by a dispatched restart, an
+  observed outage, or a 2-of-3 reboot-signal vote. Restart is a one-shot
+  command that no longer blocks while probing.
+- **Less recorder load.** Per-minute error rate sensors answer rate
+  questions without querying the lifetime counters, which remain,
+  supporting entities are categorized as Diagnostic, Docsis Status
+  folded into Status, and System Uptime and Current Time were retired
+  as values with no historical worth. (Related to #178)
+- **Less collected about you.** Serial number and MAC address are no
+  longer collected at all, and passwords are scrubbed from auth failure
+  logs before those logs are trimmed.
+- **Stable channel entity IDs.** New installs number channels by
+  position, so entity IDs survive a modem reboot renumbering its
+  channels. Existing installs keep ID-based naming, and the
+  `convert_channel_identity` service migrates statistics if you switch.
+- **Core is a standalone library.** The modem layer publishes to PyPI as
+  `solentlabs-cable-modem-monitor-core` and Home Assistant is one
+  consumer of it. HACS installs from a zip release asset of about 130 KB
+  instead of the full source archive.
+- **Dashboard and notifications.** The status card contents are
+  configurable, restart asks for confirmation, and the integration
+  raises a notification when bonded channel totals change so a stale
+  dashboard can be refreshed.
+
+Every change is listed in the beta sections below.
+
 ## [3.14.0-beta.24] - 2026-08-26
 
 ### Fixed

--- a/custom_components/cable_modem_monitor/const.py
+++ b/custom_components/cable_modem_monitor/const.py
@@ -8,7 +8,7 @@ from homeassistant.const import Platform
 
 # IMPORTANT: Do not edit VERSION manually!
 # Use: python scripts/release.py <version>
-VERSION = "3.14.0-beta.24"
+VERSION = "3.14.0"
 
 DOMAIN = "cable_modem_monitor"
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON]

--- a/custom_components/cable_modem_monitor/manifest.json
+++ b/custom_components/cable_modem_monitor/manifest.json
@@ -17,8 +17,8 @@
     "solentlabs.cable_modem_monitor_catalog"
   ],
   "requirements": [
-    "solentlabs-cable-modem-monitor-core==3.14.0-beta.24",
-    "solentlabs-cable-modem-monitor-catalog==3.14.0-beta.24"
+    "solentlabs-cable-modem-monitor-core==3.14.0",
+    "solentlabs-cable-modem-monitor-catalog==3.14.0"
   ],
-  "version": "3.14.0-beta.24"
+  "version": "3.14.0"
 }

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -364,7 +364,9 @@ Contributors don't write CHANGELOG entries. The maintainer reconciles
 
 - `scripts/check_changelog.py` validates structure on every PR:
   `[Unreleased]` first, version headings well-formed and descending,
-  Keep a Changelog sections only, no roadmap P-numbers or placeholders.
+  Keep a Changelog sections plus the release-narrative ones (`Overview`,
+  `Upgrade Notes`, `Highlights...`) only, no roadmap P-numbers or
+  placeholders. Prose always sits under a `###` heading.
   It reports only on lines the branch touches, so entries published
   before these rules existed are read for context (version order,
   duplicate detection) but never flagged; `--all` covers the whole file.

--- a/packages/cable_modem_monitor_catalog/pyproject.toml
+++ b/packages/cable_modem_monitor_catalog/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solentlabs-cable-modem-monitor-catalog"
-version = "3.14.0-beta.24"
+version = "3.14.0"
 description = "Cable Modem Monitor Catalog — modem config files and parser overrides"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "solentlabs-cable-modem-monitor-core==3.14.0-beta.24",
+    "solentlabs-cable-modem-monitor-core==3.14.0",
 ]
 license = "MIT"
 authors = [

--- a/packages/cable_modem_monitor_core/pyproject.toml
+++ b/packages/cable_modem_monitor_core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solentlabs-cable-modem-monitor-core"
-version = "3.14.0-beta.24"
+version = "3.14.0"
 description = "Cable Modem Monitor Core — platform-agnostic DOCSIS monitoring engine"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/check_changelog.py
+++ b/scripts/check_changelog.py
@@ -11,8 +11,9 @@ depends on (see docs/reference/RELEASING.md § CHANGELOG ownership):
 - every other version heading is ``## [X.Y.Z] - YYYY-MM-DD`` (optional
   ``-alpha.N`` / ``-beta.N`` / ``-rc.N``) with a real date, versions are
   strictly descending, and no version appears twice
-- ``###`` headings are only the six Keep a Changelog sections, each at
-  most once per version
+- ``###`` headings are only the six Keep a Changelog sections plus the
+  release-narrative ones (``Overview``, ``Upgrade Notes``,
+  ``Highlights...``), each at most once per version
 - body text sits under a ``###`` section, never directly under a version
 - no roadmap ``P<n>`` identifiers (CLAUDE.md § No P-numbers in public
   artifacts) and no TODO / TBD / FIXME / XXX placeholders
@@ -46,6 +47,14 @@ import sys
 from pathlib import Path
 
 _SECTIONS = ("Added", "Changed", "Deprecated", "Removed", "Fixed", "Security")
+
+# A stable release carries what the six sections cannot say: what the
+# release is, and what an upgrader has to do about it. These headings
+# are allowed alongside them; prose still needs a heading above it, and
+# every other name is still rejected. "Highlights" matches by prefix so
+# it can name the version it is measured against.
+_NARRATIVE_SECTIONS = ("Overview", "Upgrade Notes")
+_NARRATIVE_PREFIXES = ("Highlights",)
 _PRERELEASE_RANK = {"alpha": 0, "beta": 1, "rc": 2}
 _RELEASE_RANK = 3
 
@@ -63,6 +72,11 @@ _HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(?P<start>\d+)(?:,(?P<count>\d+))? @@")
 # either line was touched, so adding a heading above an existing one
 # still reports.
 Problem = tuple[int, str, int | None]
+
+
+def _is_known_section(name: str) -> bool:
+    """Whether a ``###`` heading is one the changelog allows."""
+    return name in _SECTIONS or name in _NARRATIVE_SECTIONS or name.startswith(_NARRATIVE_PREFIXES)
 
 
 def _version_key(match: re.Match[str]) -> tuple[int, ...]:
@@ -121,8 +135,9 @@ class _Validator:
         self._start_block()
 
     def _section(self, lineno: int, name: str) -> None:
-        if name not in _SECTIONS:
-            self._add(lineno, f"unknown section '{name}' (expected one of {', '.join(_SECTIONS)})")
+        if not _is_known_section(name):
+            allowed = ", ".join((*_SECTIONS, *_NARRATIVE_SECTIONS, *_NARRATIVE_PREFIXES))
+            self._add(lineno, f"unknown section '{name}' (expected one of {allowed})")
         elif name in self.sections_in_block:
             self._add(lineno, f"section '{name}' repeated within the same version", self.sections_in_block[name])
         self.sections_in_block[name] = lineno

--- a/tests/components/test_version_and_startup.py
+++ b/tests/components/test_version_and_startup.py
@@ -22,7 +22,7 @@ class TestVersion:
         Use: python scripts/release.py <version>
         The script updates const.py, manifest.json, and this file.
         """
-        assert VERSION == "3.14.0-beta.24"
+        assert VERSION == "3.14.0"
 
     def test_startup_log_message_format(self):
         """The startup log line includes the version string."""

--- a/tests/lib/test_check_changelog.py
+++ b/tests/lib/test_check_changelog.py
@@ -182,6 +182,60 @@ def test_well_formed_changelog_is_clean() -> None:
     assert _messages(lines) == []
 
 
+# ┌────────────────────────────────┬──────────────────────────────────────┐
+# │ narrative heading              │ description                          │
+# ├────────────────────────────────┼──────────────────────────────────────┤
+# fmt: off
+NARRATIVE_SECTIONS = [
+    ("### Overview",                 "release front door intro"),
+    ("### Upgrade Notes",            "what an upgrader must do"),
+    ("### Highlights since v1.0.0",  "highlights, qualified by version"),
+]
+# fmt: on
+# └────────────────────────────────┴──────────────────────────────────────┘
+
+
+@pytest.mark.parametrize(
+    ("heading", "desc"),
+    NARRATIVE_SECTIONS,
+    ids=[case[1] for case in NARRATIVE_SECTIONS],
+)
+def test_narrative_sections_are_accepted(heading: str, desc: str) -> None:
+    """A release front door carries prose sections the six cannot express."""
+    lines = [*_HEADER, "## [1.0.0] - 2026-01-01", "", heading, "", "Prose.", ""]
+    assert _messages(lines) == [], f"Failed: {desc}"
+
+
+def test_narrative_allowance_does_not_open_the_section_list() -> None:
+    """Live counterpart: an unknown section is still rejected."""
+    lines = [*_HEADER, "## [1.0.0] - 2026-01-01", "", "### Notes", "", "Prose.", ""]
+    assert any("unknown section 'Notes'" in message for message in _messages(lines))
+
+
+def test_narrative_allowance_does_not_permit_orphan_prose() -> None:
+    """Live counterpart: prose still needs a section above it."""
+    lines = [*_HEADER, "## [1.0.0] - 2026-01-01", "", "Prose with no section.", ""]
+    assert any("body text must be under a ### section" in message for message in _messages(lines))
+
+
+def test_repeated_narrative_section_is_reported() -> None:
+    """The repeat rule covers narrative sections too."""
+    lines = [
+        *_HEADER,
+        "## [1.0.0] - 2026-01-01",
+        "",
+        "### Upgrade Notes",
+        "",
+        "- x.",
+        "",
+        "### Upgrade Notes",
+        "",
+        "- y.",
+        "",
+    ]
+    assert any("repeated within the same version" in message for message in _messages(lines))
+
+
 def test_prerelease_versions_order_correctly() -> None:
     """release < rc < beta < alpha, descending, is a valid sequence."""
     lines = [*_HEADER]
@@ -318,7 +372,7 @@ def test_real_changelog_sections_are_known_in_the_unreleased_block() -> None:
     # An empty Unreleased block is the normal state between a release bump and
     # the next entry, so only the names are asserted, never their presence.
     sections = [line[4:] for line in lines[start:end] if line.startswith("### ")]
-    assert all(name in _mod._SECTIONS for name in sections), sections
+    assert all(_mod._is_known_section(name) for name in sections), sections
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The stable cut of the v3.14 line, after more than three months in public
beta. Cut off `main` at beta.24, two commits: the CHANGELOG front door
and the version bump.

## What is in the diff

Nine files, and none of them runtime code. The CHANGELOG `[3.14.0]`
section, the version strings in `const.py`, `manifest.json` and both
pyprojects, a RELEASING.md touch-up, and an allowlist in
`check_changelog.py` so the release narrative can use `Overview`,
`Upgrade Notes` and `Highlights` headings, with tests covering the
allowance and a mutation check confirming the gate still rejects
everything else.

The code shipping here is the code that shipped in beta.24 and soaked
for 22 hours on an MB7621 without a failed poll.

## What this means for the 73 installs still on 3.13.x

They get the stable offer automatically, and they have never run any
3.14 code. The Upgrade Notes in the CHANGELOG are written for them: the
config entry migrates in place and keeps entity IDs, history and
automations, but dashboards need regenerating, and the untagged v3.13.2
changes reach stable installs for the first time here.

Beta testers need the Reset Entities button, plus three narrow
remove-and-re-add cases listed in the notes.

Full detail is in CHANGELOG.md, which is also what the GitHub Release
body is built from.
