### PR TITLE
Remove channel bond change notification

### DIFF
--- a/custom_components/cable_modem_monitor/__init__.py
+++ b/custom_components/cable_modem_monitor/__init__.py
@@ -57,7 +57,6 @@ from solentlabs.cable_modem_monitor_core.post_processor import (
 from .channel_bond_notifier import (
     ChannelTotals,
     evaluate,
-    format_change_message,
     format_onboarding_message,
 )
 from .channel_bond_storage import (
@@ -136,12 +135,16 @@ async def _check_channel_bond_change(
     orchestrator: Orchestrator,
     model: str,
 ) -> None:
-    """Detect channel-bond total changes and fire the appropriate notification.
+    """Fire the one-time onboarding notification once the modem is online.
 
     Silent on the first post-upgrade poll (no retroactive onboarding) and
-    while a recovery window is open (transient count flux is expected).
-    Persists the baseline to a dedicated ``Store`` — not entry data —
-    so baseline updates don't trip the integration's update listener.
+    while a recovery window is open. Persists the baseline to a dedicated
+    ``Store`` — not entry data — so writes don't trip the integration's
+    update listener.
+
+    Totals changing after onboarding is deliberately not reported; see
+    HA_ADAPTER_SPEC.md § Notifications and #197. The counts stay on the
+    DS and US Channel Count sensors every poll.
     """
     modem_data = snapshot.modem_data
     if not modem_data:
@@ -172,21 +175,15 @@ async def _check_channel_bond_change(
     if action == "silent_init":
         return
 
-    if action == "onboarding":
-        title = "Cable Modem Monitor: Modem online"
-        message = format_onboarding_message(model=model, current=current)
-        notification_id = f"cable_modem_monitor_onboarding_{entry.entry_id}"
-    else:
-        # "change" — evaluate only returns this when stored is not None.
-        assert stored is not None
-        title = "Cable Modem Monitor: Channel bond changed"
-        message = format_change_message(model=model, prior=stored, current=current)
-        notification_id = f"cable_modem_monitor_channel_change_{entry.entry_id}"
-
+    # Only "onboarding" reaches here — "none" and "silent_init" returned above.
     await hass.services.async_call(
         "persistent_notification",
         "create",
-        {"title": title, "message": message, "notification_id": notification_id},
+        {
+            "title": "Cable Modem Monitor: Modem online",
+            "message": format_onboarding_message(model=model, current=current),
+            "notification_id": f"cable_modem_monitor_onboarding_{entry.entry_id}",
+        },
     )
 
 

--- a/custom_components/cable_modem_monitor/channel_bond_notifier.py
+++ b/custom_components/cable_modem_monitor/channel_bond_notifier.py
@@ -1,17 +1,19 @@
-"""Channel-bond change detection — pure logic.
+"""Channel-bond onboarding detection — pure logic.
 
-Decides whether a poll should fire a persistent notification based on
-prior/current totals, recovery state, and whether the entry was set
-up after this feature landed (eligible for onboarding) or upgraded
-from an older version (not eligible — silent init only).
+Decides whether a poll should fire the one-time onboarding notification,
+based on whether any state has been stored for this entry yet and whether
+the entry was set up after this feature landed (eligible for onboarding)
+or upgraded from an older version (not eligible — silent init only).
 
 HA-free so tests can run without mocks. Persistence is handled by
 :mod:`channel_bond_storage`; the coordinator wires both together and
 fires the HA ``persistent_notification.create`` service.
 
-Tracks bonded channel totals only (downstream + upstream). Per-type
-reshuffles at equal totals (e.g. QAM −1, OFDM +1) are not detected;
-this is a known gap documented in HA_ADAPTER_SPEC.md.
+Tracks bonded channel totals only (downstream + upstream). Changes to
+those totals no longer notify — see ``docs/HA_ADAPTER_SPEC.md``
+§ Notifications and #197. The totals remain available every poll on the
+DS and US Channel Count sensors, which automations can consume without
+interrupting anyone.
 """
 
 from __future__ import annotations
@@ -21,7 +23,7 @@ from typing import Literal
 
 from .channel_bond_storage import BondState
 
-NotifierAction = Literal["none", "silent_init", "onboarding", "change"]
+NotifierAction = Literal["none", "silent_init", "onboarding"]
 
 
 @dataclass(frozen=True)
@@ -48,13 +50,17 @@ def evaluate(
             ``False`` for entries upgraded from an older version.
         recovery_active: Orchestrator's recovery flag. Counts flux
             during a recovery window is expected and suppressed.
+
+    ``stored`` is still read even though the totals are no longer
+    compared: its presence is what distinguishes an already-onboarded
+    entry from a fresh one, so the onboarding notification fires exactly
+    once per config entry.
     """
     # A zero-channel reading means "no data yet" (booting / no_signal page),
     # never a real bond — an operational modem always reports channels. Don't
     # act on it and (since the call site only persists when action != "none")
     # don't let it become the stored baseline. This is the primary guard:
-    # recovery_active is time-boxed and a real outage can outlive the window,
-    # at which point a transient 0 would otherwise be read as a 24 → 0 change.
+    # recovery_active is time-boxed and a real outage can outlive the window.
     if current.downstream == 0 and current.upstream == 0:
         return "none"
 
@@ -64,9 +70,13 @@ def evaluate(
     if stored is None:
         return "onboarding" if onboarding_eligible else "silent_init"
 
-    if current.downstream != stored.baseline_downstream or current.upstream != stored.baseline_upstream:
-        return "change"
-
+    # Totals differing from the stored baseline is deliberately not an
+    # action. The comparison watched bonded totals rather than entities,
+    # which is the wrong value in both directions: a DOCSIS 3.1 OFDM
+    # carrier that briefly drops and returns produces two notifications
+    # for a single poll of missing data, while an ID-mode channel
+    # reassignment — the case this was built for — can leave the totals
+    # unchanged and go undetected. See #197.
     return "none"
 
 
@@ -77,24 +87,4 @@ def format_onboarding_message(*, model: str, current: ChannelTotals) -> str:
         f"{current.upstream} upstream bonded channels. You can auto-generate "
         f"a Lovelace dashboard for this modem via Developer Tools → Actions → "
         f"`cable_modem_monitor.generate_dashboard`."
-    )
-
-
-def format_change_message(
-    *,
-    model: str,
-    prior: BondState,
-    current: ChannelTotals,
-) -> str:
-    """Body text describing which totals changed."""
-    deltas: list[str] = []
-    if prior.baseline_downstream != current.downstream:
-        deltas.append(f"downstream {prior.baseline_downstream} → {current.downstream}")
-    if prior.baseline_upstream != current.upstream:
-        deltas.append(f"upstream {prior.baseline_upstream} → {current.upstream}")
-    delta_text = ", ".join(deltas)
-    return (
-        f"{model} channel bond changed: {delta_text}. Your generated "
-        f"dashboard may be out of date — re-run Developer Tools → Actions → "
-        f"`cable_modem_monitor.generate_dashboard` to refresh."
     )

--- a/custom_components/cable_modem_monitor/docs/HA_ADAPTER_SPEC.md
+++ b/custom_components/cable_modem_monitor/docs/HA_ADAPTER_SPEC.md
@@ -1328,19 +1328,30 @@ automation:
 
 ---
 
-## Channel Bond Change Notifications
+## Notifications
 
-The data coordinator fires persistent notifications when bonded channel
-totals shift between polls. Two triggers share one mechanism; both
-point the user at `generate_dashboard` so they can refresh a stale
-Lovelace dashboard.
+A persistent notification is warranted only when the user has something to act
+on, or to confirm an action they just took. Before adding one, name which of
+the two it is. If it is neither, use an entity or the
+`cable_modem_monitor_data_updated` event instead, which automations can consume
+without interrupting anyone.
 
-**Triggers:**
+The integration raises five. The auth lockout asks you to fix your credentials.
+Restart sent, restart failed and entity reset complete each confirm a button
+press. The onboarding message confirms the modem came online after you added
+it, and fires once per config entry. Channel bond totals changing is neither of
+those, and the totals are already on the DS and US Channel Count sensors, which
+is why it is being removed in 3.14.1 (#197).
+
+### Channel bond onboarding
+
+The data coordinator fires one persistent notification per config entry, the
+first time a successful poll reports channel totals. It points the user at
+`generate_dashboard` so they can build a Lovelace dashboard for the modem.
 
 | Trigger | When it fires | Notification ID |
 |---------|---------------|-----------------|
 | Onboarding | First successful poll after setup | `cable_modem_monitor_onboarding_{entry_id}` |
-| Change | Downstream or upstream total differs from the persisted baseline | `cable_modem_monitor_channel_change_{entry_id}` |
 
 Stable IDs per entry mean re-firing replaces rather than stacks.
 
@@ -1356,13 +1367,13 @@ Stable IDs per entry mean re-firing replaces rather than stacks.
   `{baseline_downstream: int, baseline_upstream: int}`. Presence of a
   Store payload means the entry has already been onboarded (fresh) or
   silently baselined (upgrade); absence means the next successful poll
-  should run first-time logic.
+  should run first-time logic. The totals themselves are no longer
+  compared — presence is what carries the meaning.
 
 **Why Store, not entry data.** The integration's update listener
-reloads the integration on **any** entry-data mutation. If baseline
-totals were stored on the entry, every real channel-count change
-would fire a reload — exactly when the user wants stability. The
-Store helper persists per-entry state without tripping listeners.
+reloads the integration on **any** entry-data mutation, so per-entry
+state that changes at runtime cannot live there. The Store helper
+persists it without tripping listeners.
 
 **Suppression rules:**
 
@@ -1370,17 +1381,13 @@ Store helper persists per-entry state without tripping listeners.
   yet" — a booting or `no_signal` page returns empty channel tables,
   not a real bond. The notifier returns `none` and the coordinator
   never persists it as a baseline. An operational modem always reports
-  channels, so a zero total is never a legitimate bond change. This is
-  the primary guard because it holds regardless of outage length:
+  channels, so a zero total is never a legitimate reading. This is the
+  primary guard because it holds regardless of outage length:
   `recovery_active` is time-boxed, and a real outage can outlive the
-  window, at which point a transient `0` would otherwise be read as a
-  `24 → 0` change, persisted as the baseline, and then re-fire as a
-  `0 → 24` change once channels return.
-- **Recovery guard (secondary).** Comparison is skipped while
-  `orchestrator.recovery_active` is `True`. Non-zero counts can still
-  flux while a recovery window is open (channels renegotiate the bond,
-  e.g. `24 → 23`); the baseline is preserved so a transient that
-  resolves back to the prior totals produces no notification.
+  window, at which point a transient `0` would otherwise be stored as
+  the baseline.
+- **Recovery guard (secondary).** Skipped while
+  `orchestrator.recovery_active` is `True`.
 
 **Upgrade path:** entries created before this feature lack
 `CONF_CHANNEL_ONBOARDING_ELIGIBLE`. On first post-upgrade poll the
@@ -1390,20 +1397,20 @@ retroactive onboarding notification.
 **Cleanup.** `async_remove_entry` in `__init__.py` removes the Store
 payload when the config entry is deleted.
 
-**Known gap — totals only.** The notifier tracks summed downstream and
-upstream counts, not per-channel-type (QAM/OFDM/ATDMA/OFDMA).
-A reshuffle that leaves the total unchanged (e.g. QAM −1, OFDM +1 on
-DOCSIS 3.1 provisioning changes) is not detected. This is a
-deliberate simplification; per-type tracking can be added later if
-field reports indicate real misses.
+**Removed in 3.14.1 — the change notification.** Bonded totals differing
+from the stored baseline used to fire a second notification. It watched
+the wrong value in both directions: a DOCSIS 3.1 OFDM carrier that
+briefly drops and returns cost two notifications for a single poll of
+missing data, while an ID-mode channel reassignment — the case it was
+built for — can leave the totals unchanged and go undetected. Defaulting
+identity mode to channel number was the real fix for the latter. See
+#197.
 
 **Pure logic lives in `channel_bond_notifier.py`** (no HA imports), so
 the decision tree is unit-testable without mocks. The coordinator owns
 the HA integration: reading `system_info`, reading
-`orchestrator.recovery_active`, persisting entry data, and calling
+`orchestrator.recovery_active`, persisting the Store payload, and calling
 `persistent_notification.create`.
-
----
 
 ## Config Entry Migration
 

--- a/tests/components/test_channel_bond_notifier.py
+++ b/tests/components/test_channel_bond_notifier.py
@@ -1,7 +1,7 @@
-"""Tests for the pure channel-bond change detection logic.
+"""Tests for the pure channel-bond onboarding detection logic.
 
 Pure logic — no HA dependency. Exercises every branch of ``evaluate``
-with a table plus focused checks on the message formatters.
+with a table plus a focused check on the onboarding message formatter.
 """
 
 from __future__ import annotations
@@ -11,7 +11,6 @@ import pytest
 from custom_components.cable_modem_monitor.channel_bond_notifier import (
     ChannelTotals,
     evaluate,
-    format_change_message,
     format_onboarding_message,
 )
 from custom_components.cable_modem_monitor.channel_bond_storage import BondState
@@ -37,9 +36,20 @@ EVAL_CASES = [
     ("upgraded_entry_no_stored", None, False, False, "silent_init"),
     ("onboarded_steady", _MATCHING_STATE, True, False, "none"),
     ("upgraded_steady_after_silent_init", _MATCHING_STATE, False, False, "none"),
-    ("ds_changed", _STALE_DS_STATE, True, False, "change"),
-    ("us_changed", _STALE_US_STATE, True, False, "change"),
-    ("both_changed", _STALE_BOTH_STATE, True, False, "change"),
+    # Totals differing from the stored baseline is no longer an action.
+    # The comparison watched bonded totals rather than entities, which is
+    # the wrong value in both directions: a DOCSIS 3.1 OFDM carrier that
+    # briefly drops and returns produced two notifications for a single
+    # poll of missing data, while an ID-mode channel reassignment — the
+    # case it was built for — can leave the totals unchanged and go
+    # undetected. Removed in 3.14.1 (#197).
+    ("ds_differs_not_actionable", _STALE_DS_STATE, True, False, "none"),
+    ("us_differs_not_actionable", _STALE_US_STATE, True, False, "none"),
+    ("both_differ_not_actionable", _STALE_BOTH_STATE, True, False, "none"),
+    # Onboarding must still fire on a fresh entry whose totals happen to
+    # differ from nothing at all — the stored-is-None branch is what
+    # distinguishes a fresh entry, not the totals.
+    ("fresh_setup_ignores_totals", None, True, False, "onboarding"),
 ]
 
 
@@ -58,6 +68,25 @@ def test_evaluate(desc, stored, onboarding_eligible, recovery_active, expected):
     assert result == expected
 
 
+def test_evaluate_never_returns_change():
+    """No combination of inputs produces a change action.
+
+    Belt and braces alongside the table: the action was removed rather
+    than made harder to reach, so nothing should be able to surface it.
+    """
+    stored_options = [None, _MATCHING_STATE, _STALE_DS_STATE, _STALE_US_STATE, _STALE_BOTH_STATE]
+    for stored in stored_options:
+        for eligible in (True, False):
+            for recovery in (True, False):
+                result = evaluate(
+                    current=_CURRENT,
+                    stored=stored,
+                    onboarding_eligible=eligible,
+                    recovery_active=recovery,
+                )
+                assert result in {"none", "onboarding", "silent_init"}
+
+
 # ---------------------------------------------------------------------
 # evaluate() — zero-totals guard
 #
@@ -67,6 +96,10 @@ def test_evaluate(desc, stored, onboarding_eligible, recovery_active, expected):
 # exists. Regression: a ~1h45m outage outlived the time-boxed recovery
 # window, so a transient 0-channel reading was stored as baseline and the
 # subsequent recovery looked like a 0 → 24 change. (MB7621, v3.14.0-beta.11)
+#
+# The change action is gone as of 3.14.1 (#197), so the recovery half of
+# that regression can no longer notify — but the guard still has to keep
+# (0, 0) out of the Store, which is what these cases assert.
 # ---------------------------------------------------------------------
 
 _ZERO = ChannelTotals(downstream=0, upstream=0)
@@ -107,18 +140,8 @@ def test_onboarding_message_includes_counts_and_service():
     assert "cable_modem_monitor.generate_dashboard" in message
 
 
-def test_change_message_reports_only_changed_direction():
-    prior = BondState(baseline_downstream=24, baseline_upstream=4)
-    current = ChannelTotals(downstream=23, upstream=4)
-    message = format_change_message(model="TPS-2000", prior=prior, current=current)
-    assert "downstream 24 → 23" in message
-    assert "upstream" not in message
-    assert "cable_modem_monitor.generate_dashboard" in message
+def test_change_message_formatter_is_gone():
+    """The change formatter no longer exists (#197)."""
+    from custom_components.cable_modem_monitor import channel_bond_notifier
 
-
-def test_change_message_reports_both_when_both_shift():
-    prior = BondState(baseline_downstream=24, baseline_upstream=4)
-    current = ChannelTotals(downstream=23, upstream=5)
-    message = format_change_message(model="TPS-2000", prior=prior, current=current)
-    assert "downstream 24 → 23" in message
-    assert "upstream 4 → 5" in message
+    assert not hasattr(channel_bond_notifier, "format_change_message")

--- a/tests/components/test_init.py
+++ b/tests/components/test_init.py
@@ -782,8 +782,15 @@ async def test_channel_bond_upgraded_entry_silent_init():
     hass.services.async_call.assert_not_called()
 
 
-async def test_channel_bond_change_fires_notification():
-    """Totals differing from baseline fire the change notification."""
+async def test_channel_bond_change_no_longer_notifies():
+    """Totals differing from baseline produce no notification and no Store write.
+
+    The change notification was removed in 3.14.1 (#197). A DOCSIS 3.1
+    OFDM carrier that drops for a single poll and returns used to produce
+    two notifications — one for the fall, one when the baseline moved
+    back — on a line that was never degraded. The counts remain on the
+    DS and US Channel Count sensors.
+    """
     from custom_components.cable_modem_monitor.channel_bond_storage import BondState
 
     entry_data = {"channel_onboarding_eligible": True}
@@ -806,11 +813,42 @@ async def test_channel_bond_change_fires_notification():
         await _check_channel_bond_change(hass, entry, snapshot, orchestrator, "TPS-2000")
 
     hass.config_entries.async_update_entry.assert_not_called()
-    assert mock_save.call_args.args[2].baseline_downstream == 23
+    # No re-baseline: the Store is untouched, so the entry stays "onboarded"
+    # and a genuine fresh install is still distinguishable from this one.
+    mock_save.assert_not_awaited()
+    hass.services.async_call.assert_not_called()
 
-    payload = hass.services.async_call.call_args.args[2]
-    assert payload["notification_id"] == "cable_modem_monitor_channel_change_entry_abc"
-    assert "downstream 24 → 23" in payload["message"]
+
+async def test_channel_bond_recovered_totals_no_longer_notify():
+    """The other half of the OFDM blink — totals returning to baseline.
+
+    The old behaviour re-baselined on the drop, so the recovery read as a
+    second change and notified again. With no re-baseline on either side,
+    neither poll does anything.
+    """
+    from custom_components.cable_modem_monitor.channel_bond_storage import BondState
+
+    entry_data = {"channel_onboarding_eligible": True}
+    hass, entry, orchestrator, snapshot = _make_bond_test_harness(
+        entry_data=entry_data,
+        snapshot=_make_snapshot(downstream_count=24, upstream_count=4),
+    )
+    prior = BondState(baseline_downstream=23, baseline_upstream=4)
+
+    with (
+        patch(
+            "custom_components.cable_modem_monitor.async_load_bond_state",
+            AsyncMock(return_value=prior),
+        ),
+        patch(
+            "custom_components.cable_modem_monitor.async_save_bond_state",
+            AsyncMock(),
+        ) as mock_save,
+    ):
+        await _check_channel_bond_change(hass, entry, snapshot, orchestrator, "TPS-2000")
+
+    mock_save.assert_not_awaited()
+    hass.services.async_call.assert_not_called()
 
 
 async def test_channel_bond_steady_counts_no_op():


### PR DESCRIPTION
Supersedes #202, which closed when I deleted my fork.


Removes the channel-bond change notification. Onboarding and silent init are untouched.

The detector compared bonded totals against a stored baseline and notified on any difference. That watches the wrong value in both directions:

A DOCSIS 3.1 OFDM carrier that briefly drops and returns costs one poll of data on that channel and nothing else, but produces two notifications — one when the total falls, another when it recovers and the baseline moves back. On my line that was 28 notifications in a week, none of which corresponded to a real problem.
The case it was built for — an ID-mode channel reassignment leaving entities stranded — can leave the totals unchanged, so the comparison finds nothing. Defaulting identity mode to channel number was the real fix for that.

The totals remain on the DS and US Channel Count sensors every poll, so nothing that was observable stops being observable; it just stops interrupting.

Changes
channel_bond_notifier.py — drop "change" from NotifierAction, drop the comparison branch in evaluate(), drop format_change_message. evaluate() still reads stored to distinguish a fresh entry from an onboarded one.
init.py — drop the change branch in _check_channel_bond_change.
tests/components/test_channel_bond_notifier.py, tests/components/test_init.py — the change cases become assertions that differing totals produce no notification and no Store write.
custom_components/cable_modem_monitor/docs/HA_ADAPTER_SPEC.md — section retitled to Notifications, change trigger removed, policy added.
Deliberately not touched
The Store. Its payload looks vestigial once the comparison is gone, but its presence is what tells an onboarded entry from a fresh one. Changing it would break the upgrade path on existing installs.
The onboarding notification.
Core, the parsers, and the channel count sensors.
Entity creation and the mapping manager.
No new config option.
Tests

Written first. Against current main four assertions fail:

ds_differs_not_actionable got "change", want "none"
us_differs_not_actionable got "change", want "none"
both_differ_not_actionable got "change", want "none"
format_change_message still present

After the change, none do. No new scaffolding — the existing decision table and harness cover it.

test_init.py gains a second case for the other half of an OFDM blink: totals returning to the baseline. Under the old behaviour the drop re-baselined, so the recovery read as a second change and notified again — that pair is what made one blink cost two notifications.

I don't have a local dev environment, so CI is the first real run of these tests. The test-first ordering is in the commit history.

Two things I left alone, flagging rather than assuming
_check_channel_bond_change now only does onboarding, so the name is a bit off. Renaming touches test_init.py's import list — happy to do it in a follow-up if you want.
channel_bond_storage.py's module docstring still says "for the channel-bond change notifier". You asked me not to touch the Store, so I haven't, but the wording is now stale.