### PR TITLE
fix: v3.14.1-beta.2 - generated dashboards read entity IDs from the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Generated dashboards pointed at entities that do not exist (#205).**
+  The dashboard generator built entity IDs from the configured entity
+  prefix. Home Assistant composes entity IDs from the device name, so
+  renaming the device renames them, and every generated reference then
+  read "Entity not found". Entity IDs now come from the entity registry
+  and match whatever the entities are actually called. A reference that
+  cannot be resolved, including one for an entity you have disabled, is
+  left out instead of emitted broken. The channel identity converter and
+  the orphaned statistics tool read the same source, so on a renamed
+  device they now find the statistics they previously skipped.
+
 ## [3.14.1-beta.1] - 2026-08-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.14.1-beta.2] - 2026-09-01
+
 ### Fixed
 
 - **Generated dashboards pointed at entities that do not exist (#205).**

--- a/custom_components/cable_modem_monitor/const.py
+++ b/custom_components/cable_modem_monitor/const.py
@@ -8,7 +8,7 @@ from homeassistant.const import Platform
 
 # IMPORTANT: Do not edit VERSION manually!
 # Use: python scripts/release.py <version>
-VERSION = "3.14.1-beta.1"
+VERSION = "3.14.1-beta.2"
 
 DOMAIN = "cable_modem_monitor"
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON]

--- a/custom_components/cable_modem_monitor/dev_tools.py
+++ b/custom_components/cable_modem_monitor/dev_tools.py
@@ -20,6 +20,7 @@ import homeassistant.helpers.device_registry as dr
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.recorder import get_instance
 from homeassistant.util import slugify as ha_slugify
 
@@ -78,16 +79,66 @@ def _resolve_config_entry_for_device(
 
 
 # ------------------------------------------------------------------
-# Entity ID prefix — matches _update_device_registry in __init__.py
+# Entity ID resolution — the registry is the authority (#205)
 # ------------------------------------------------------------------
 
+# Probe for the live prefix: every install has a Status sensor, and its
+# unique ID suffix and entity ID suffix are both "status".
+_PREFIX_PROBE_SUFFIX = "status"
 
-def _get_entity_prefix(entry: CableModemConfigEntry) -> str:
-    """Derive the entity ID prefix from config entry settings.
 
-    Must match the device_name logic in get_device_name() so
-    generated entity IDs match what HA actually creates.
+class _EntityResolver:
+    """Maps a dashboard reference to the entity ID HA actually assigned.
+
+    ``has_entity_name = True`` composes entity IDs from the device name, so
+    renaming the device renames them. Only the unique ID is ours and stable,
+    so that is the key (#205).
     """
+
+    def __init__(self, hass: HomeAssistant, entry: CableModemConfigEntry) -> None:
+        self._registry = er.async_get(hass)
+        self._entry_id = entry.entry_id
+
+    def sensor(self, unique_suffix: str) -> str | None:
+        """Entity ID for a sensor, or None when absent or disabled."""
+        return self._lookup("sensor", f"{self._entry_id}_cable_modem_{unique_suffix}")
+
+    def button(self, unique_suffix: str) -> str | None:
+        """Entity ID for a button, or None when absent or disabled."""
+        # Buttons carry no ``cable_modem_`` infix.
+        return self._lookup("button", f"{self._entry_id}_{unique_suffix}")
+
+    def _lookup(self, domain: str, unique_id: str) -> str | None:
+        entity_id = self._registry.async_get_entity_id(domain, DOMAIN, unique_id)
+        if entity_id is None:
+            return None
+        record = self._registry.async_get(entity_id)
+        # Disabled keeps an ID but carries no state, so the row renders
+        # empty. hidden_by is not checked: hidden entities still have state
+        # and render when a card names them directly.
+        if record is not None and record.disabled_by is not None:
+            return None
+        return entity_id
+
+
+def _emit(lines: list[str], entity_id: str | None, *rows: str) -> None:
+    """Append an entity row plus its trailing *rows*, or nothing if unresolved."""
+    if entity_id is None:
+        return
+    lines.append(f"      - entity: {entity_id}")
+    lines.extend(rows)
+
+
+def _get_entity_prefix(entry: CableModemConfigEntry, resolver: _EntityResolver | None = None) -> str:
+    """The live entity ID prefix, probed from the registry, else settings.
+
+    Statistic IDs are historical strings with no unique ID to look up, so
+    the statistic tools need the prefix itself.
+    """
+    if resolver is not None:
+        probe = resolver.sensor(_PREFIX_PROBE_SUFFIX)
+        if probe is not None:
+            return probe.split(".", 1)[1].removesuffix(f"_{_PREFIX_PROBE_SUFFIX}")
     data = entry.data
     device_name = get_device_name(
         data.get(CONF_ENTITY_PREFIX, "default"),
@@ -263,8 +314,46 @@ def _format_channel_label(
     return f"{ch_type.upper()} Ch {ch_id}"
 
 
+def _status_row_yaml(resolver: _EntityResolver, status_id: str | None) -> list[str]:
+    """The Status row, with a refresh tap target when that button resolves."""
+    if status_id is None:
+        return []
+    rows = [f"      - entity: {status_id}", "        name: Status"]
+    refresh_id = resolver.button("update_data_button")
+    # Without the tap target the row still works, minus the refresh shortcut.
+    if refresh_id is not None:
+        rows.extend(
+            [
+                "        tap_action:",
+                "          action: call-service",
+                "          service: button.press",
+                "          target:",
+                f"            entity_id: {refresh_id}",
+            ]
+        )
+    return rows
+
+
+def _passthrough_rows(
+    resolver: _EntityResolver,
+    system_info: dict[str, Any],
+    exclude_fields: frozenset[str],
+) -> list[str]:
+    """Rows for system_info fields with no dedicated sensor class (tier 2/3)."""
+    rows: list[str] = []
+    for field in sorted(system_info):
+        if (
+            field in CONSUMED_SYSTEM_INFO_FIELDS  # includes docsis_status (attribute row above)
+            or field in DISPLAY_ONLY_SYSTEM_INFO_FIELDS
+            or field in exclude_fields
+        ):
+            continue
+        _emit(rows, resolver.sensor(field), f"        name: {field.replace('_', ' ').title()}")
+    return rows
+
+
 def _build_status_card_yaml(
-    entity_prefix: str,
+    resolver: _EntityResolver,
     system_info: dict[str, Any],
     *,
     has_icmp: bool,
@@ -273,124 +362,84 @@ def _build_status_card_yaml(
 ) -> list[str]:
     """Build YAML for the status entities card.
 
-    Only includes entities for fields the modem actually provides.
-    Channel counts and status are always present; everything else is
-    gated on system_info field presence (matching sensor.py gating).
-
-    Args:
-        entity_prefix: Entity ID prefix (e.g., "cable_modem").
-        system_info: The system_info dict from modem data.
-        has_icmp: Whether ICMP ping latency entity exists.
-        has_head: Whether the HTTP HEAD latency entity exists
-            (only created on supports_head=True modems).
-        exclude_fields: Pass-through fields to omit from the card;
-            defaults to STATUS_CARD_DEFAULT_EXCLUDE.
+    ``system_info`` decides which entities belong, mirroring sensor.py's
+    gating; the resolver decides what they are called.
     """
     if exclude_fields is None:
         exclude_fields = frozenset(STATUS_CARD_DEFAULT_EXCLUDE)
-    lines = [
-        "  - type: entities",
-        "    title: Cable Modem Status",
-        "    entities:",
-        f"      - entity: sensor.{entity_prefix}_status",
-        "        name: Status",
-        "        tap_action:",
-        "          action: call-service",
-        "          service: button.press",
-        "          target:",
-        f"            entity_id: button.{entity_prefix}_update_modem_data",
-    ]
+    status_id = resolver.sensor("status")
+    lines: list[str] = list(_status_row_yaml(resolver, status_id))
     if has_icmp:
-        lines.append(f"      - entity: sensor.{entity_prefix}_ping_latency")
-        lines.append("        name: Ping")
-    lines.extend(
-        [
-            f"      - entity: sensor.{entity_prefix}_tcp_latency",
-            "        name: TCP",
-            "        icon: mdi:transit-connection-variant",
-        ]
+        _emit(lines, resolver.sensor("ping_latency"), "        name: Ping")
+    _emit(
+        lines,
+        resolver.sensor("tcp_latency"),
+        "        name: TCP",
+        "        icon: mdi:transit-connection-variant",
     )
     if has_head:
-        lines.extend(
-            [
-                f"      - entity: sensor.{entity_prefix}_http_latency",
-                "        name: HTTP",
-                "        icon: mdi:speedometer",
-            ]
+        _emit(
+            lines,
+            resolver.sensor("http_latency"),
+            "        name: HTTP",
+            "        icon: mdi:speedometer",
         )
     # DOCSIS status renders as an `attribute` row off the Status sensor
     # (the standalone sensor was retired, #178) at its historical
     # position (the pre-beta.12 "Modem Status" spot). The row shows the
     # raw value (e.g. `operational`); prettifying needs a template card.
-    if "docsis_status" in system_info and "docsis_status" not in exclude_fields:
+    if "docsis_status" in system_info and "docsis_status" not in exclude_fields and status_id is not None:
         lines.append("      - type: attribute")
-        lines.append(f"        entity: sensor.{entity_prefix}_status")
+        lines.append(f"        entity: {status_id}")
         lines.append("        attribute: docsis_status")
         lines.append("        name: DOCSIS Status")
     if "software_version" in system_info:
-        lines.append(f"      - entity: sensor.{entity_prefix}_software_version")
-        lines.append("        name: Software Version")
+        _emit(lines, resolver.sensor("software_version"), "        name: Software Version")
     # Uptime is a display-time calculation, not a sensor (#178): both
     # rows render Last Boot Time — relative ("5 days ago") for uptime,
     # absolute for the boot instant. Gate mirrors sensor.py's Last
     # Boot Time creation gate.
     if "system_uptime" in system_info or "total_corrected" in system_info or "total_uncorrected" in system_info:
-        lines.extend(
-            [
-                f"      - entity: sensor.{entity_prefix}_last_boot_time",
-                "        name: Uptime",
-                "        format: relative",
-                f"      - entity: sensor.{entity_prefix}_last_boot_time",
-                "        name: Last Boot",
-                "        format: datetime",
-            ]
-        )
-    lines.extend(
-        [
-            f"      - entity: sensor.{entity_prefix}_ds_channel_count",
-            "        name: Downstream Channel Count",
-            f"      - entity: sensor.{entity_prefix}_us_channel_count",
-            "        name: Upstream Channel Count",
-        ]
-    )
+        boot_id = resolver.sensor("last_boot_time")
+        _emit(lines, boot_id, "        name: Uptime", "        format: relative")
+        _emit(lines, boot_id, "        name: Last Boot", "        format: datetime")
+    _emit(lines, resolver.sensor("downstream_channel_count"), "        name: Downstream Channel Count")
+    _emit(lines, resolver.sensor("upstream_channel_count"), "        name: Upstream Channel Count")
     # Error totals only — the rate sensors exist as HA entities but
     # are intentionally omitted from the status entities row. Rates
     # are point-in-time MEASUREMENT values that jitter poll-to-poll;
     # the summary row is for stable identity/state, the rate trend
     # belongs in a history graph (see include_error_rates).
     if "total_corrected" in system_info:
-        lines.extend(
-            [
-                f"      - entity: sensor.{entity_prefix}_total_corrected_errors",
-                "        name: Total Corrected Errors",
-                f"      - entity: sensor.{entity_prefix}_total_uncorrected_errors",
-                "        name: Total Uncorrected Errors",
-            ]
-        )
-    for field in sorted(system_info):
-        if (
-            field in CONSUMED_SYSTEM_INFO_FIELDS  # includes docsis_status (attribute row above)
-            or field in DISPLAY_ONLY_SYSTEM_INFO_FIELDS
-            or field in exclude_fields
-        ):
-            continue
-        lines.append(f"      - entity: sensor.{entity_prefix}_{field}")
-        lines.append(f"        name: {field.replace('_', ' ').title()}")
-    lines.append("    show_header_toggle: false")
-    lines.append("    state_color: false")
-    return lines
+        _emit(lines, resolver.sensor("total_corrected"), "        name: Total Corrected Errors")
+        _emit(lines, resolver.sensor("total_uncorrected"), "        name: Total Uncorrected Errors")
+    lines.extend(_passthrough_rows(resolver, system_info, exclude_fields))
+    # Drop the card rather than emit an empty shell, as the graphs do.
+    if not lines:
+        return []
+    return [
+        "  - type: entities",
+        "    title: Cable Modem Status",
+        "    entities:",
+        *lines,
+        "    show_header_toggle: false",
+        "    state_color: false",
+    ]
 
 
-def _build_restart_button_card_yaml(entity_prefix: str) -> list[str]:
+def _build_restart_button_card_yaml(resolver: _EntityResolver) -> list[str]:
     """Build YAML for the standalone restart button card.
 
     A dedicated `button` card is used instead of an entities-row so the
     confirmation dialog reliably guards every tap. In an entities card,
     clicking the button widget bypasses the row's tap_action.
     """
+    restart_id = resolver.button("restart_button")
+    if restart_id is None:
+        return []
     return [
         "  - type: button",
-        f"    entity: button.{entity_prefix}_restart_modem",
+        f"    entity: {restart_id}",
         "    name: Restart Modem",
         "    icon: mdi:restart",
         "    show_state: false",
@@ -398,36 +447,55 @@ def _build_restart_button_card_yaml(entity_prefix: str) -> list[str]:
         "      action: call-service",
         "      service: button.press",
         "      target:",
-        f"        entity_id: button.{entity_prefix}_restart_modem",
+        f"        entity_id: {restart_id}",
         "      confirmation:",
         "        text: This will restart your modem and temporarily disconnect your internet.",
     ]
 
 
 def _build_channel_graph_yaml(
+    resolver: _EntityResolver,
     title: str,
     hours: int,
     channel_info: list[tuple[str, int]],
-    entity_pattern: str,
+    unique_pattern: str,
     channel_label: str,
 ) -> list[str]:
-    """Build YAML for a channel history graph card."""
-    yaml_parts = [
+    """Build YAML for a channel history graph card.
+
+    *unique_pattern* is a unique ID suffix template, not an entity ID.
+    """
+    rows: list[str] = []
+    for ch_type, ch_id in channel_info:
+        entity_id = resolver.sensor(unique_pattern.format(ch_type=ch_type, ch_id=ch_id))
+        _emit(rows, entity_id, f"        name: {_format_channel_label(ch_type, ch_id, channel_label)}")
+    if not rows:
+        return []
+    return [
         "  - type: history-graph",
         f"    title: {title}",
         f"    hours_to_show: {hours}",
         "    entities:",
+        *rows,
     ]
-    for ch_type, ch_id in channel_info:
-        entity_id = entity_pattern.format(ch_type=ch_type, ch_id=ch_id)
-        label = _format_channel_label(ch_type, ch_id, channel_label)
-        yaml_parts.append(f"      - entity: {entity_id}")
-        yaml_parts.append(f"        name: {label}")
-    return yaml_parts
+
+
+def _single_entity_graph(entity_id: str | None, title: str, hours: int, label: str) -> list[str]:
+    """A one-line history graph, or nothing when the entity does not resolve."""
+    if entity_id is None:
+        return []
+    return [
+        "  - type: history-graph",
+        f"    title: {title}",
+        f"    hours_to_show: {hours}",
+        "    entities:",
+        f"      - entity: {entity_id}",
+        f"        name: {label}",
+    ]
 
 
 def _build_error_graphs_yaml(
-    entity_prefix: str,
+    resolver: _EntityResolver,
     titles: dict[str, str],
     *,
     include_rates: bool = False,
@@ -441,41 +509,27 @@ def _build_error_graphs_yaml(
     trend over time enable ``include_error_rates`` on the service call.
     """
     lines = [
-        "  - type: history-graph",
-        f"    title: {titles['corrected']}",
-        "    hours_to_show: 168",
-        "    entities:",
-        f"      - entity: sensor.{entity_prefix}_total_corrected_errors",
-        "        name: Corrected Error Count",
-        "  - type: history-graph",
-        f"    title: {titles['uncorrected']}",
-        "    hours_to_show: 168",
-        "    entities:",
-        f"      - entity: sensor.{entity_prefix}_total_uncorrected_errors",
-        "        name: Uncorrected Error Count",
+        *_single_entity_graph(resolver.sensor("total_corrected"), titles["corrected"], 168, "Corrected Error Count"),
+        *_single_entity_graph(
+            resolver.sensor("total_uncorrected"), titles["uncorrected"], 168, "Uncorrected Error Count"
+        ),
     ]
     if include_rates:
         lines.extend(
             [
-                "  - type: history-graph",
-                f"    title: {titles['corrected_rate']}",
-                "    hours_to_show: 168",
-                "    entities:",
-                f"      - entity: sensor.{entity_prefix}_rate_corrected_errors",
-                "        name: Corrected Error Rate",
-                "  - type: history-graph",
-                f"    title: {titles['uncorrected_rate']}",
-                "    hours_to_show: 168",
-                "    entities:",
-                f"      - entity: sensor.{entity_prefix}_rate_uncorrected_errors",
-                "        name: Uncorrected Error Rate",
+                *_single_entity_graph(
+                    resolver.sensor("rate_corrected"), titles["corrected_rate"], 168, "Corrected Error Rate"
+                ),
+                *_single_entity_graph(
+                    resolver.sensor("rate_uncorrected"), titles["uncorrected_rate"], 168, "Uncorrected Error Rate"
+                ),
             ]
         )
     return lines
 
 
 def _build_latency_graph_yaml(
-    entity_prefix: str,
+    resolver: _EntityResolver,
     *,
     has_icmp: bool,
     has_head: bool,
@@ -485,28 +539,29 @@ def _build_latency_graph_yaml(
     Always graphs TCP latency (the L4 reachability signal). Adds Ping
     and HTTP HEAD lines only when those entities exist for this modem.
     """
-    lines = [
+    rows: list[str] = []
+    if has_icmp:
+        _emit(rows, resolver.sensor("ping_latency"), "        name: Ping")
+    _emit(rows, resolver.sensor("tcp_latency"), "        name: TCP")
+    if has_head:
+        _emit(rows, resolver.sensor("http_latency"), "        name: HTTP")
+    if not rows:
+        return []
+    return [
         "  - type: history-graph",
         "    title: Latency",
         "    hours_to_show: 6",
         "    entities:",
+        *rows,
     ]
-    if has_icmp:
-        lines.append(f"      - entity: sensor.{entity_prefix}_ping_latency")
-        lines.append("        name: Ping")
-    lines.append(f"      - entity: sensor.{entity_prefix}_tcp_latency")
-    lines.append("        name: TCP")
-    if has_head:
-        lines.append(f"      - entity: sensor.{entity_prefix}_http_latency")
-        lines.append("        name: HTTP")
-    return lines
 
 
 def _add_channel_graphs(
     yaml_parts: list[str],
+    resolver: _EntityResolver,
     channel_info: list[tuple[str, int]],
     base_title: str,
-    entity_pattern: str,
+    unique_pattern: str,
     graph_hours: int,
     channel_label: str,
     channel_grouping: str,
@@ -530,10 +585,11 @@ def _add_channel_graphs(
             effective_label = "id_only" if channel_label == "auto" else channel_label
             yaml_parts.extend(
                 _build_channel_graph_yaml(
+                    resolver,
                     title,
                     graph_hours,
                     channels,
-                    entity_pattern,
+                    unique_pattern,
                     effective_label,
                 )
             )
@@ -547,32 +603,32 @@ def _add_channel_graphs(
             effective_label = "full" if channel_label == "auto" else channel_label
         yaml_parts.extend(
             _build_channel_graph_yaml(
+                resolver,
                 title,
                 graph_hours,
                 channel_info,
-                entity_pattern,
+                unique_pattern,
                 effective_label,
             )
         )
 
 
 def _build_channel_graph_defs(
-    entity_prefix: str,
     identity_mode: ChannelIdentity,
     downstream_info: list[tuple[str, int]],
     upstream_info: list[tuple[str, int]],
 ) -> list[tuple[str, list[tuple[str, int]], str, str]]:
     """Build the channel graph definitions for the dashboard.
 
-    Returns (opt_key, channel_info, title_key, entity_pattern) tuples.
+    Returns (opt_key, channel_info, title_key, unique_pattern) tuples,
+    the pattern being a ChannelSensor unique ID suffix.
     """
-    p = entity_prefix
     if identity_mode == ChannelIdentity.NUMBER:
-        ds = f"sensor.{p}_ds_ch_{{ch_id}}"
-        us = f"sensor.{p}_us_ch_{{ch_id}}"
+        ds = "ds_ch_{ch_id}"
+        us = "us_ch_{ch_id}"
     else:
-        ds = f"sensor.{p}_ds_{{ch_type}}_ch_{{ch_id}}"
-        us = f"sensor.{p}_us_{{ch_type}}_ch_{{ch_id}}"
+        ds = "ds_{ch_type}_ch_{ch_id}"
+        us = "us_{ch_type}_ch_{ch_id}"
     # fmt: off
     return [
         ("ds_power", downstream_info, "ds_power", f"{ds}_power"),
@@ -612,7 +668,7 @@ def create_generate_dashboard_handler(
         """Handle the generate_dashboard service call."""
         entry, modem_data = _resolve_dashboard_target(hass, call)
 
-        entity_prefix = _get_entity_prefix(entry)
+        resolver = _EntityResolver(hass, entry)
         has_icmp = bool(entry.data.get(CONF_SUPPORTS_ICMP, False))
         has_head = bool(entry.data.get(CONF_SUPPORTS_HEAD, False))
         has_restart = entry.runtime_data.orchestrator.supports_restart
@@ -638,17 +694,13 @@ def create_generate_dashboard_handler(
         identity_mode = ChannelIdentity(entry.data.get(CONF_CHANNEL_IDENTITY, ChannelIdentity.ID))
         downstream_info, upstream_info = _get_channel_info(modem_data, identity_mode)
 
-        yaml_parts = [
-            "# Cable Modem Dashboard",
-            "# Copy from here, paste into: Dashboard > Add Card > Manual",
-            "type: vertical-stack",
-            "cards:",
-        ]
+        # Kept apart from the header so an empty result is detectable.
+        yaml_parts: list[str] = []
 
         if opts["status"]:
             yaml_parts.extend(
                 _build_status_card_yaml(
-                    entity_prefix,
+                    resolver,
                     system_info,
                     has_icmp=has_icmp,
                     has_head=has_head,
@@ -657,22 +709,22 @@ def create_generate_dashboard_handler(
             )
 
         if has_restart:
-            yaml_parts.extend(_build_restart_button_card_yaml(entity_prefix))
+            yaml_parts.extend(_build_restart_button_card_yaml(resolver))
 
         channel_graphs = _build_channel_graph_defs(
-            entity_prefix,
             identity_mode,
             downstream_info,
             upstream_info,
         )
 
-        for opt_key, ch_info, title_key, entity_pattern in channel_graphs:
+        for opt_key, ch_info, title_key, unique_pattern in channel_graphs:
             if opts[opt_key]:
                 _add_channel_graphs(
                     yaml_parts,
+                    resolver,
                     ch_info,
                     titles[title_key],
-                    entity_pattern,
+                    unique_pattern,
                     graph_hours,
                     channel_label,
                     channel_grouping,
@@ -682,7 +734,7 @@ def create_generate_dashboard_handler(
         if opts["errors"] and "total_corrected" in system_info:
             yaml_parts.extend(
                 _build_error_graphs_yaml(
-                    entity_prefix,
+                    resolver,
                     titles,
                     include_rates=opts["error_rates"],
                 )
@@ -691,19 +743,35 @@ def create_generate_dashboard_handler(
         if opts["latency"]:
             yaml_parts.extend(
                 _build_latency_graph_yaml(
-                    entity_prefix,
+                    resolver,
                     has_icmp=has_icmp,
                     has_head=has_head,
                 )
+            )
+
+        if not yaml_parts:
+            # An empty cards: list is invalid Lovelace and explains nothing.
+            raise ServiceValidationError(
+                "No entities found for this modem — it may still be starting up, " "or its entities may be disabled"
             )
 
         _LOGGER.info(
             "Generated dashboard: %d DS channels, %d US channels, prefix=%s",
             len(downstream_info),
             len(upstream_info),
-            entity_prefix,
+            _get_entity_prefix(entry, resolver),
         )
-        return {"yaml": "\n".join(yaml_parts)}
+        return {
+            "yaml": "\n".join(
+                [
+                    "# Cable Modem Dashboard",
+                    "# Copy from here, paste into: Dashboard > Add Card > Manual",
+                    "type: vertical-stack",
+                    "cards:",
+                    *yaml_parts,
+                ]
+            )
+        }
 
     return handle_generate_dashboard
 
@@ -847,7 +915,7 @@ def create_convert_channel_identity_handler(
             raise ServiceValidationError("No modem data available — the modem must be online")
 
         channels = _build_channel_lookup(snapshot.modem_data)
-        prefix = _get_entity_prefix(entry)
+        prefix = _get_entity_prefix(entry, _EntityResolver(hass, entry))
 
         # Query recorder for all statistic IDs.
         from homeassistant.components.recorder.statistics import (
@@ -925,7 +993,7 @@ def create_orphaned_statistics_handler(
         if entry is None:
             raise ServiceValidationError("No cable modem configured")
 
-        prefix = _get_entity_prefix(entry)
+        prefix = _get_entity_prefix(entry, _EntityResolver(hass, entry))
 
         from homeassistant.components.recorder.statistics import (
             async_list_statistic_ids,

--- a/custom_components/cable_modem_monitor/docs/HA_ADAPTER_SPEC.md
+++ b/custom_components/cable_modem_monitor/docs/HA_ADAPTER_SPEC.md
@@ -1246,8 +1246,39 @@ form, as a single global readability preference.
 
 1. Resolves target modem from `device_id` or falls back to first entry
 2. Reads current channel data from `entry.runtime_data.data_coordinator`
-3. Generates entity references for actual channels
-4. Returns YAML string the user pastes into a manual dashboard card
+3. Decides which entities belong on the dashboard from that data
+4. Resolves each one's entity ID from the entity registry by unique ID
+5. Returns YAML string the user pastes into a manual dashboard card
+
+**Entity IDs come from the registry, never from the entity prefix.**
+Steps 3 and 4 answer different questions. Whether an entity *belongs* is
+answered by the modem data: no `total_corrected` in `system_info` means no
+error rows. What it is *called* is answered only by the registry, because
+`has_entity_name = True` composes entity IDs from the device name, so
+renaming the device renames them. An ID assembled from `entity_prefix`
+holds only for a default-named, never-renamed install (#205).
+
+Every entity carries a unique ID the integration owns, making the lookup
+exact: `er.async_get_entity_id(domain, DOMAIN, unique_id)`. Unique IDs are
+not derivable from entity IDs — `sensor.{prefix}_ds_channel_count` is
+`{entry_id}_cable_modem_downstream_channel_count`,
+`button.{prefix}_update_modem_data` is `{entry_id}_update_data_button` — so
+the mapping is written out explicitly and tested against the entity classes
+that mint it.
+
+An unresolved reference is **omitted**, covering a disabled entity
+(`disabled_by` set: an ID but no state) and one never created. `hidden_by`
+is not consulted; hidden entities still render when named directly. A card
+with no rows is dropped, and if nothing at all resolves the service raises
+`ServiceValidationError` rather than return a `vertical-stack` whose empty
+`cards:` list is invalid Lovelace.
+
+`convert_channel_identity` and `orphaned_statistics` cannot use this lookup:
+recorder statistic IDs are historical strings that outlive their entities.
+They need the prefix itself, and probe it from the Status sensor, falling
+back to the settings-derived name only before any entity registers. On a
+renamed install this is a behavior change — both previously matched zero
+statistic IDs and silently did nothing.
 
 ### `request_refresh`
 

--- a/custom_components/cable_modem_monitor/manifest.json
+++ b/custom_components/cable_modem_monitor/manifest.json
@@ -17,8 +17,8 @@
     "solentlabs.cable_modem_monitor_catalog"
   ],
   "requirements": [
-    "solentlabs-cable-modem-monitor-core==3.14.1-beta.1",
-    "solentlabs-cable-modem-monitor-catalog==3.14.1-beta.1"
+    "solentlabs-cable-modem-monitor-core==3.14.1-beta.2",
+    "solentlabs-cable-modem-monitor-catalog==3.14.1-beta.2"
   ],
-  "version": "3.14.1-beta.1"
+  "version": "3.14.1-beta.2"
 }

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -33,8 +33,11 @@ Releases follow a PR-based workflow:
 
 ### 1. Prepare the Release (on feature branch)
 
-Run `scripts/check_owned_deps.py` and batch-update anything shown —
-releases shouldn't ship with stale declared deps.
+`make validate-ci` ends with `scripts/check_owned_deps.py`. It is
+informational and always exits 0: it compares the local venv against
+PyPI, so a package it lists may already be permitted by our declared
+floor. Read it, and open a separate deps commit if something we declare
+is genuinely behind. It does not gate a release.
 
 ```bash
 # Ensure you're on your feature branch with all changes committed
@@ -76,24 +79,40 @@ gh pr create --title "feat: v3.14.0 - Your Release Title" --body "..."
 ### 3. Review and Merge
 
 - Wait for CI to pass
-- Review the changes
-- Merge the PR (squash or merge commit)
+- Review the changes, including the PR **description**: `make
+  autoclose-check` scans commit bodies only, so a `Fixes #N` in the body
+  is the one auto-close vector nothing catches
+- Merge with a **merge commit, never a squash**. **Where tags live**
+  tags the merge commit, and a squash produces none; a squash also
+  rewrites the head SHAs GitHub uses to mark a PR merged, which costs a
+  fork contributor their merged badge and authorship
+- `require-pr-approval` cannot be satisfied by the author, so this is a
+  `gh pr merge --merge --admin` in practice. Confirm every check is
+  green first: the admin flag overrides required status checks too, not
+  just the review requirement
 
 ### 4. Tag Main and Push
 
 After the PR is merged:
 
+Tag the merge commit by SHA. Don't `git checkout main` first: local
+`main` never moves in this workflow (see **Where tags live**), so a
+checkout-then-tag risks tagging a stale commit, and it disturbs the
+working tree for no gain.
+
 ```bash
-# Switch to main and pull the merged changes
-git checkout main
-git pull origin main
+git fetch origin
 
-# Create the release tag on main
-git tag -a v3.14.0 -m "Cable Modem Monitor v3.14.0
+# The merge commit the PR produced, straight from GitHub
+MERGE_SHA=$(gh api repos/solentlabs/cable_modem_monitor/pulls/204 -q .merge_commit_sha)
 
-Key features:
-- Feature 1
-- Feature 2
+# Confirm it is what main points at before tagging it
+git rev-parse origin/main
+
+git tag -a v3.14.0 "$MERGE_SHA" -m "Cable Modem Monitor v3.14.0
+
+- Highlight 1
+- Highlight 2
 - See CHANGELOG.md for details"
 
 # Push the tag (triggers release workflow)
@@ -104,8 +123,12 @@ git push origin v3.14.0
 
 The tag push triggers `.github/workflows/release.yml` which:
 
-- Creates a GitHub Release
-- Attaches release notes from the tag message
+- Creates a GitHub Release, `prerelease` for a beta tag
+- Builds the release body from the matching `## [X.Y.Z]` section of
+  `CHANGELOG.md`, **not** from the tag message. The tag message is for
+  readers of `git`; what users see is the changelog section, so that
+  section has to be right before the tag is pushed.
+- Attaches the `cable_modem_monitor.zip` asset HACS installs from
 
 Verify at: <https://github.com/solentlabs/cable_modem_monitor/releases>
 

--- a/packages/cable_modem_monitor_catalog/pyproject.toml
+++ b/packages/cable_modem_monitor_catalog/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solentlabs-cable-modem-monitor-catalog"
-version = "3.14.1-beta.1"
+version = "3.14.1-beta.2"
 description = "Cable Modem Monitor Catalog — modem config files and parser overrides"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "solentlabs-cable-modem-monitor-core==3.14.1-beta.1",
+    "solentlabs-cable-modem-monitor-core==3.14.1-beta.2",
 ]
 license = "MIT"
 authors = [

--- a/packages/cable_modem_monitor_core/pyproject.toml
+++ b/packages/cable_modem_monitor_core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solentlabs-cable-modem-monitor-core"
-version = "3.14.1-beta.1"
+version = "3.14.1-beta.2"
 description = "Cable Modem Monitor Core — platform-agnostic DOCSIS monitoring engine"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/components/test_services.py
+++ b/tests/components/test_services.py
@@ -27,6 +27,7 @@ from custom_components.cable_modem_monitor.dev_tools import (
     _build_latency_graph_yaml,
     _build_restart_button_card_yaml,
     _build_status_card_yaml,
+    _EntityResolver,
     _find_loaded_entry,
     _format_channel_label,
     _format_title_with_type,
@@ -214,7 +215,7 @@ def test_build_status_card_yaml_full():
         "rate_uncorrected": 0.0,
     }
     lines = _build_status_card_yaml(
-        "cable_modem",
+        _resolver_for(),
         system_info,
         has_icmp=True,
         has_head=True,
@@ -241,7 +242,7 @@ def test_build_status_card_yaml_minimal():
     """Status card omits entities when modem data is sparse and HEAD unsupported."""
     system_info = {}
     lines = _build_status_card_yaml(
-        "cable_modem",
+        _resolver_for(),
         system_info,
         has_icmp=False,
         has_head=False,
@@ -271,7 +272,7 @@ def test_build_status_card_yaml_passthrough_fields():
         "total_uncorrected": 0,
         "rate_corrected": 5.0,
     }
-    lines = _build_status_card_yaml("cable_modem", system_info, has_icmp=False, has_head=False)
+    lines = _build_status_card_yaml(_resolver_for(), system_info, has_icmp=False, has_head=False)
     yaml = "\n".join(lines)
     assert "sensor.cable_modem_ds_power_status" in yaml
     assert "sensor.cable_modem_ds_snr_status" in yaml
@@ -312,7 +313,9 @@ def test_passthrough_formerly_explicit_fields(system_info: dict[str, Any], expec
     Exclusion is disabled here — this test asserts loop reach, not the
     default exclusion policy (covered below).
     """
-    lines = _build_status_card_yaml("modem", system_info, has_icmp=False, has_head=False, exclude_fields=frozenset())
+    lines = _build_status_card_yaml(
+        _resolver_for("modem"), system_info, has_icmp=False, has_head=False, exclude_fields=frozenset()
+    )
     assert expected_entity in "\n".join(lines)
 
 
@@ -325,7 +328,7 @@ def test_status_card_display_only_fields_never_appear():
         "software_version": "1.0",
         "ds_power_status": "Good",
     }
-    lines = _build_status_card_yaml("modem", system_info, has_icmp=False, has_head=False)
+    lines = _build_status_card_yaml(_resolver_for("modem"), system_info, has_icmp=False, has_head=False)
     yaml = "\n".join(lines)
     assert "hardware_version" not in yaml
     assert "model_name" not in yaml
@@ -350,7 +353,7 @@ def test_status_card_exclude_override():
     }
     yaml = "\n".join(
         _build_status_card_yaml(
-            "modem",
+            _resolver_for("modem"),
             system_info,
             has_icmp=False,
             has_head=False,
@@ -367,7 +370,7 @@ def test_status_card_exclude_drops_docsis_row():
     system_info = {"docsis_status": "Operational"}
     yaml = "\n".join(
         _build_status_card_yaml(
-            "modem",
+            _resolver_for("modem"),
             system_info,
             has_icmp=False,
             has_head=False,
@@ -379,7 +382,7 @@ def test_status_card_exclude_drops_docsis_row():
 
 def test_build_restart_button_card_yaml():
     """Restart button is a dedicated `button` card so confirmation always fires."""
-    lines = _build_restart_button_card_yaml("cable_modem")
+    lines = _build_restart_button_card_yaml(_resolver_for())
     yaml = "\n".join(lines)
     assert "type: button" in yaml
     assert "entity: button.cable_modem_restart_modem" in yaml
@@ -396,10 +399,11 @@ def test_build_channel_graph_yaml():
     """Channel graph card has correct entity IDs and labels."""
     info = [("qam", 1), ("qam", 2)]
     lines = _build_channel_graph_yaml(
+        _resolver_for("cm"),
         "DS Power",
         24,
         info,
-        "sensor.cm_ds_{ch_type}_ch_{ch_id}_power",
+        "ds_{ch_type}_ch_{ch_id}_power",
         "full",
     )
     yaml = "\n".join(lines)
@@ -412,7 +416,7 @@ def test_build_channel_graph_yaml():
 def test_build_error_graphs_yaml_counts_only_by_default():
     """Default: counts only — rate graphs are opt-in via include_rates."""
     titles = _get_dashboard_titles(False)
-    lines = _build_error_graphs_yaml("cm", titles)
+    lines = _build_error_graphs_yaml(_resolver_for("cm"), titles)
     yaml = "\n".join(lines)
     assert "sensor.cm_total_corrected_errors" in yaml
     assert "sensor.cm_total_uncorrected_errors" in yaml
@@ -423,7 +427,7 @@ def test_build_error_graphs_yaml_counts_only_by_default():
 def test_build_error_graphs_yaml_with_rates_opt_in():
     """include_rates=True appends rate history graphs after counts."""
     titles = _get_dashboard_titles(False)
-    lines = _build_error_graphs_yaml("cm", titles, include_rates=True)
+    lines = _build_error_graphs_yaml(_resolver_for("cm"), titles, include_rates=True)
     yaml = "\n".join(lines)
     assert "sensor.cm_total_corrected_errors" in yaml
     assert "sensor.cm_total_uncorrected_errors" in yaml
@@ -433,7 +437,7 @@ def test_build_error_graphs_yaml_with_rates_opt_in():
 
 def test_build_latency_graph_yaml_with_icmp_and_head():
     """Latency graph includes Ping, TCP, and HTTP HEAD when all available."""
-    lines = _build_latency_graph_yaml("cm", has_icmp=True, has_head=True)
+    lines = _build_latency_graph_yaml(_resolver_for("cm"), has_icmp=True, has_head=True)
     yaml = "\n".join(lines)
     assert "sensor.cm_ping_latency" in yaml
     assert "sensor.cm_tcp_latency" in yaml
@@ -442,7 +446,7 @@ def test_build_latency_graph_yaml_with_icmp_and_head():
 
 def test_build_latency_graph_yaml_no_icmp_no_head():
     """Latency graph omits Ping and HTTP when unavailable; TCP always present."""
-    lines = _build_latency_graph_yaml("cm", has_icmp=False, has_head=False)
+    lines = _build_latency_graph_yaml(_resolver_for("cm"), has_icmp=False, has_head=False)
     yaml = "\n".join(lines)
     assert "ping_latency" not in yaml
     assert "sensor.cm_tcp_latency" in yaml
@@ -451,7 +455,7 @@ def test_build_latency_graph_yaml_no_icmp_no_head():
 
 def test_build_latency_graph_yaml_icmp_only():
     """Latency graph: ICMP supported but HEAD not — no HTTP line."""
-    lines = _build_latency_graph_yaml("cm", has_icmp=True, has_head=False)
+    lines = _build_latency_graph_yaml(_resolver_for("cm"), has_icmp=True, has_head=False)
     yaml = "\n".join(lines)
     assert "sensor.cm_ping_latency" in yaml
     assert "sensor.cm_tcp_latency" in yaml
@@ -469,9 +473,10 @@ def test_add_channel_graphs_by_direction_single_type():
     info = [("qam", 1), ("qam", 2)]
     _add_channel_graphs(
         parts,
+        _resolver_for("cm"),
         info,
         "Downstream Power Levels (dBmV)",
-        "sensor.cm_ds_{ch_type}_ch_{ch_id}_power",
+        "ds_{ch_type}_ch_{ch_id}_power",
         24,
         "auto",
         "by_direction",
@@ -488,9 +493,10 @@ def test_add_channel_graphs_by_type():
     info = [("qam", 1), ("ofdm", 33)]
     _add_channel_graphs(
         parts,
+        _resolver_for("cm"),
         info,
         "DS Power",
-        "sensor.cm_ds_{ch_type}_ch_{ch_id}_power",
+        "ds_{ch_type}_ch_{ch_id}_power",
         24,
         "auto",
         "by_type",
@@ -506,9 +512,10 @@ def test_add_channel_graphs_empty():
     parts: list[str] = []
     _add_channel_graphs(
         parts,
+        _resolver_for("cm"),
         [],
         "DS Power",
-        "sensor.cm_ds_{ch_type}_ch_{ch_id}_power",
+        "ds_{ch_type}_ch_{ch_id}_power",
         24,
         "auto",
         "by_direction",
@@ -880,12 +887,34 @@ async def test_request_health_check_no_entries_raises() -> None:
 
 
 def test_get_entity_prefix() -> None:
-    """Entity prefix derived from device name via slugification."""
+    """With no resolver, the prefix falls back to the device name slug."""
     entry = MagicMock()
     entry.data = {"entity_prefix": "none", "host": "192.168.100.1"}
     entry.runtime_data.modem_identity.model = "TPS-2000"
 
     assert _get_entity_prefix(entry) == "cable_modem"
+
+
+def test_get_entity_prefix_reads_registry_over_settings() -> None:
+    """A registered Status sensor wins over the settings-derived name (#205)."""
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.data = {"entity_prefix": "none", "host": "192.168.100.1"}
+    entry.runtime_data.modem_identity.model = "TPS-2000"
+
+    resolver = _resolver_for("dan_room_arris_cable_modem")
+
+    assert _get_entity_prefix(entry, resolver) == "dan_room_arris_cable_modem"
+
+
+def test_get_entity_prefix_falls_back_when_nothing_registered() -> None:
+    """Before any entity registers, the probe misses and settings answer."""
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.data = {"entity_prefix": "none", "host": "192.168.100.1"}
+    entry.runtime_data.modem_identity.model = "TPS-2000"
+
+    assert _get_entity_prefix(entry, _resolver_for(empty=True)) == "cable_modem"
 
 
 # -----------------------------------------------------------------------
@@ -923,9 +952,10 @@ def test_add_channel_graphs_multi_type_by_direction() -> None:
     info = [("qam", 1), ("ofdm", 33)]
     _add_channel_graphs(
         parts,
+        _resolver_for("cm"),
         info,
         "Downstream Power Levels (dBmV)",
-        "sensor.cm_ds_{ch_type}_ch_{ch_id}_power",
+        "ds_{ch_type}_ch_{ch_id}_power",
         24,
         "auto",
         "by_direction",
@@ -995,6 +1025,197 @@ def test_generate_dashboard_handler(
     assert "sensor.cable_modem_tcp_latency" in yaml
     assert "sensor.cable_modem_http_latency" in yaml
     assert "entity: button.cable_modem_restart_modem" in yaml
+
+
+# Suffixes where the entity ID and unique ID spellings diverge (#205).
+_SENSOR_UID_TO_EID = {
+    "downstream_channel_count": "ds_channel_count",
+    "upstream_channel_count": "us_channel_count",
+    "total_corrected": "total_corrected_errors",
+    "total_uncorrected": "total_uncorrected_errors",
+    "rate_corrected": "rate_corrected_errors",
+    "rate_uncorrected": "rate_uncorrected_errors",
+}
+_BUTTON_UID_TO_EID = {
+    "restart_button": "restart_modem",
+    "update_data_button": "update_modem_data",
+    "reset_entities_button": "reset_entities",
+}
+
+
+class _FakeRegistryEntry:
+    """Minimal stand-in for a registry entry — only `disabled_by` is read."""
+
+    def __init__(self, disabled_by: str | None = None) -> None:
+        self.disabled_by = disabled_by
+
+
+class _FakeEntityRegistry:
+    """Registry double where every entity the integration mints is registered.
+
+    ``disabled`` and ``empty`` carve exceptions out of that default.
+    """
+
+    def __init__(
+        self,
+        entry_id: str = "test_entry",
+        prefix: str = "cable_modem",
+        disabled: set[str] | None = None,
+        empty: bool = False,
+    ) -> None:
+        self._entry_id = entry_id
+        self._prefix = prefix
+        self._disabled = disabled or set()
+        self._empty = empty
+        self._known: set[str] = set()
+
+    def async_get_entity_id(self, domain: str, platform: str, unique_id: str) -> str | None:
+        if self._empty or platform != DOMAIN or not unique_id.startswith(f"{self._entry_id}_"):
+            return None
+        suffix = unique_id[len(self._entry_id) + 1 :]
+        if domain == "button":
+            eid_suffix = _BUTTON_UID_TO_EID.get(suffix)
+        elif domain == "sensor" and suffix.startswith("cable_modem_"):
+            uid_suffix = suffix[len("cable_modem_") :]
+            eid_suffix = _SENSOR_UID_TO_EID.get(uid_suffix, uid_suffix)
+        else:
+            eid_suffix = None
+        if eid_suffix is None:
+            return None
+        entity_id = f"{domain}.{self._prefix}_{eid_suffix}"
+        self._known.add(entity_id)
+        return entity_id
+
+    def async_get(self, entity_id: str) -> _FakeRegistryEntry | None:
+        if entity_id not in self._known:
+            return None
+        return _FakeRegistryEntry("user" if entity_id in self._disabled else None)
+
+
+def _registry_for(entry_id: str, prefix: str, disabled: set[str] | None = None) -> _FakeEntityRegistry:
+    """Registry double whose entity IDs carry *prefix*."""
+    return _FakeEntityRegistry(entry_id=entry_id, prefix=prefix, disabled=disabled)
+
+
+@pytest.fixture(autouse=True)
+def _default_entity_registry():
+    """Every entity registered under `cable_modem`, as a default install gets.
+
+    Tests needing a renamed, disabled, or empty registry patch over this.
+    """
+    with patch(
+        "custom_components.cable_modem_monitor.dev_tools.er.async_get",
+        return_value=_FakeEntityRegistry(),
+    ):
+        yield
+
+
+def _resolver_for(
+    prefix: str = "cable_modem",
+    entry_id: str = "test_entry",
+    **kwargs: Any,
+) -> _EntityResolver:
+    """An `_EntityResolver` backed by the registry double."""
+    entry = MagicMock()
+    entry.entry_id = entry_id
+    with patch(
+        "custom_components.cable_modem_monitor.dev_tools.er.async_get",
+        return_value=_FakeEntityRegistry(entry_id=entry_id, prefix=prefix, **kwargs),
+    ):
+        return _EntityResolver(MagicMock(), entry)
+
+
+def test_generate_dashboard_uses_registry_entity_ids(
+    mock_runtime_data: CableModemRuntimeData,
+) -> None:
+    """A renamed device yields registry entity IDs, not assembled ones (#205).
+
+    The reported install renamed the device, so every assembled
+    `sensor.cable_modem_*` reference rendered "Entity not found".
+    """
+    entry = _make_mock_entry(mock_runtime_data)
+    entry.data = {
+        "entity_prefix": "none",
+        "host": "192.168.100.1",
+        "supports_icmp": True,
+        "supports_head": True,
+    }
+
+    hass = MagicMock()
+    hass.config_entries.async_entries.return_value = [entry]
+
+    registry = _registry_for(entry.entry_id, "dan_room_arris_cable_modem")
+    with patch(
+        "custom_components.cable_modem_monitor.dev_tools.er.async_get",
+        return_value=registry,
+    ):
+        handler = create_generate_dashboard_handler(hass)
+        yaml = handler(_make_mock_call({"include_status_card": True}))["yaml"]
+
+    assert "sensor.dan_room_arris_cable_modem_status" in yaml
+    assert "sensor.dan_room_arris_cable_modem_ds_channel_count" in yaml
+    assert "sensor.dan_room_arris_cable_modem_total_corrected_errors" in yaml
+    assert "button.dan_room_arris_cable_modem_update_modem_data" in yaml
+    # The assembled form must not survive anywhere in the output.
+    assert "sensor.cable_modem_" not in yaml
+    assert "button.cable_modem_" not in yaml
+
+
+def test_generate_dashboard_omits_disabled_entities(
+    mock_runtime_data: CableModemRuntimeData,
+) -> None:
+    """An entity the user disabled has a registry ID but no state, so it is omitted."""
+    entry = _make_mock_entry(mock_runtime_data)
+    entry.data = {
+        "entity_prefix": "none",
+        "host": "192.168.100.1",
+        "supports_icmp": True,
+        "supports_head": True,
+    }
+
+    hass = MagicMock()
+    hass.config_entries.async_entries.return_value = [entry]
+
+    registry = _registry_for(
+        entry.entry_id,
+        "cable_modem",
+        disabled={"sensor.cable_modem_http_latency"},
+    )
+    with patch(
+        "custom_components.cable_modem_monitor.dev_tools.er.async_get",
+        return_value=registry,
+    ):
+        handler = create_generate_dashboard_handler(hass)
+        yaml = handler(_make_mock_call({"include_status_card": True, "include_latency": True}))["yaml"]
+
+    assert "sensor.cable_modem_tcp_latency" in yaml
+    assert "sensor.cable_modem_http_latency" not in yaml
+
+
+def test_generate_dashboard_raises_when_nothing_resolves(
+    mock_runtime_data: CableModemRuntimeData,
+) -> None:
+    """Nothing resolvable → raise; an empty `cards:` is invalid Lovelace."""
+    entry = _make_mock_entry(mock_runtime_data)
+    entry.data = {
+        "entity_prefix": "none",
+        "host": "192.168.100.1",
+        "supports_icmp": True,
+        "supports_head": True,
+    }
+
+    hass = MagicMock()
+    hass.config_entries.async_entries.return_value = [entry]
+
+    with (
+        patch(
+            "custom_components.cable_modem_monitor.dev_tools.er.async_get",
+            return_value=_FakeEntityRegistry(entry.entry_id, empty=True),
+        ),
+        pytest.raises(ServiceValidationError, match="No entities found for this modem"),
+    ):
+        handler = create_generate_dashboard_handler(hass)
+        handler(_make_mock_call({"include_status_card": True}))
 
 
 def test_generate_dashboard_handler_with_error_rates_opt_in(
@@ -1415,6 +1636,39 @@ async def test_convert_to_id_mode_migrates(mock_runtime_data) -> None:
     hass.async_create_task.assert_called_once()
 
 
+async def test_convert_uses_renamed_prefix_from_registry(mock_runtime_data) -> None:
+    """Renamed device: the conversion finds its statistics, not nothing (#205).
+
+    These stats carry only the renamed prefix, which "cable_modem" misses.
+    """
+    entry = _make_convert_runtime(mock_runtime_data, target_mode="id")
+    hass = MagicMock()
+    hass.config_entries.async_entries.return_value = [entry]
+
+    recorder = MagicMock()
+    renamed_stats = [
+        {"statistic_id": "sensor.dan_room_arris_cable_modem_ds_ch_1_power"},
+        {"statistic_id": "sensor.dan_room_arris_cable_modem_ds_ch_2_power"},
+    ]
+
+    with (
+        patch(
+            "custom_components.cable_modem_monitor.dev_tools.er.async_get",
+            return_value=_FakeEntityRegistry(entry.entry_id, "dan_room_arris_cable_modem"),
+        ),
+        patch(
+            "homeassistant.components.recorder.statistics.async_list_statistic_ids",
+            new_callable=AsyncMock,
+            return_value=renamed_stats,
+        ),
+        patch("homeassistant.helpers.recorder.get_instance", return_value=recorder),
+    ):
+        handler = create_convert_channel_identity_handler(hass)
+        result = await handler(_make_mock_call())
+
+    assert result["renamed"] >= 1
+
+
 async def test_convert_to_number_mode_migrates(mock_runtime_data) -> None:
     """ID-mode stats present + target=number → migrates via _plan_stat_renames_to_number."""
     entry = _make_convert_runtime(mock_runtime_data, target_mode="number")
@@ -1537,13 +1791,13 @@ def test_build_channel_graph_defs_number_mode_omits_channel_type() -> None:
     )
 
     defs = _build_channel_graph_defs(
-        entity_prefix="modem",
         identity_mode=ChannelIdentity.NUMBER,
         downstream_info=[("", 1)],
         upstream_info=[("", 1)],
     )
     patterns = [pattern for (_key, _info, _title, pattern) in defs]
-    # Every pattern uses the number-mode shape: sensor.{prefix}_{dir}_ch_{ch_id}_{metric}
+    # Every pattern is a unique ID suffix in the number-mode shape:
+    # {dir}_ch_{ch_id}_{metric}, with no channel type segment.
     for p in patterns:
         assert "{ch_type}" not in p
         assert "_ch_{ch_id}" in p

--- a/tests/components/test_version_and_startup.py
+++ b/tests/components/test_version_and_startup.py
@@ -22,7 +22,7 @@ class TestVersion:
         Use: python scripts/release.py <version>
         The script updates const.py, manifest.json, and this file.
         """
-        assert VERSION == "3.14.1-beta.1"
+        assert VERSION == "3.14.1-beta.2"
 
     def test_startup_log_message_format(self):
         """The startup log line includes the version string."""


### PR DESCRIPTION
## What's in it

**Generated dashboards pointed at entities that do not exist (#205).**
The dashboard generator built entity IDs from the configured entity
prefix. Home Assistant composes entity IDs from the device name, so
renaming the device renames them, and every generated reference then
read "Entity not found". Entity IDs now come from the entity registry
and match whatever the entities are actually called. A reference that
cannot be resolved, including one for a disabled entity, is left out
instead of emitted broken.

Also corrects four inaccuracies in RELEASING.md.

Addresses #205.

## Verification

Dogfooded against the local HA harness on real hardware (24 downstream,
4 upstream channels), three cases:

| check | result |
| --- | --- |
| baseline | 90 references emitted, all resolve |
| device + entity IDs renamed | all 90 follow the rename, none left on the old prefix |
| disabled entity | reference omitted rather than emitted broken |

`make validate-ci` passed on the post-bump tree. All four workflows green
on 42ad6ccf.

## Merge

Merge commit, not squash — release branch to main.
