### PR TITLE
feat: v3.14.1-beta.5 - error totals on the Technicolor XB gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Error totals and error rates on the Technicolor XB7, XB8 and XB10
   (#194).** In every capture on file from the XB6, XB7, XB8 and XB10, the
   first column of the error codeword table repeats the last column's counts,
-  so the primary channel's own counts never appear. These entries used to publish no totals at all to avoid
-  summing the copy. Now only that column is skipped, and the totals and
-  rates sum every other QAM channel. Thanks to @Boby360 for the captures.
+  so the primary channel's own counts never appear. These entries used to
+  publish no totals at all to avoid summing the copy. Now only that column
+  is skipped, and the totals and rates sum every other QAM channel. Thanks
+  to @Boby360 for the captures.
 
 - **`skip_columns` for transposed companion tables.** A parser can declare
   the data columns whose cells the firmware copies from another column, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Error totals and error rates on the Technicolor XB7, XB8 and XB10
+  (#194).** In every capture on file from the XB6, XB7, XB8 and XB10, the
+  first column of the error codeword table repeats the last column's counts,
+  so the primary channel's own counts never appear. These entries used to publish no totals at all to avoid
+  summing the copy. Now only that column is skipped, and the totals and
+  rates sum every other QAM channel. Thanks to @Boby360 for the captures.
+
+- **`skip_columns` for transposed companion tables.** A parser can declare
+  the data columns whose cells the firmware copies from another column, and
+  the table contributes nothing for them. It applies to companion tables
+  only and never removes a channel. See `FORMAT_TABLE_SPEC.md`.
+
+### Fixed
+
+- **The Technicolor XB6 error total no longer counts another channel's
+  codewords.** The same duplicated first column was summed into the XB6's
+  QAM totals, and on a lineup with two OFDM channels it carried the OFDM
+  channel's counts, putting the total in the billions. It is now skipped
+  like on the other XB gateways.
+
+### Upgrade Notes
+
+**Technicolor XB gateways.** The primary downstream channel's Corrected and
+Uncorrected sensors now read unknown, because the value they showed belonged
+to another channel. On the XB6, Total Corrected Errors and Total
+Uncorrected Errors drop to the real QAM figure on the first poll after
+upgrading, which Home Assistant records as a counter reset. XB7, XB8 and XB10
+installs gain the total and rate error sensors; run `generate_dashboard`
+again to add the error graphs.
+
 ## [3.14.1-beta.4] - 2026-09-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.14.1-beta.5] - 2026-09-10
+
 ### Added
 
 - **Error totals and error rates on the Technicolor XB7, XB8 and XB10

--- a/custom_components/cable_modem_monitor/const.py
+++ b/custom_components/cable_modem_monitor/const.py
@@ -8,7 +8,7 @@ from homeassistant.const import Platform
 
 # IMPORTANT: Do not edit VERSION manually!
 # Use: python scripts/release.py <version>
-VERSION = "3.14.1-beta.4"
+VERSION = "3.14.1-beta.5"
 
 DOMAIN = "cable_modem_monitor"
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON]

--- a/custom_components/cable_modem_monitor/manifest.json
+++ b/custom_components/cable_modem_monitor/manifest.json
@@ -17,8 +17,8 @@
     "solentlabs.cable_modem_monitor_catalog"
   ],
   "requirements": [
-    "solentlabs-cable-modem-monitor-core==3.14.1-beta.4",
-    "solentlabs-cable-modem-monitor-catalog==3.14.1-beta.4"
+    "solentlabs-cable-modem-monitor-core==3.14.1-beta.5",
+    "solentlabs-cable-modem-monitor-catalog==3.14.1-beta.5"
   ],
-  "version": "3.14.1-beta.4"
+  "version": "3.14.1-beta.5"
 }

--- a/packages/cable_modem_monitor_catalog/pyproject.toml
+++ b/packages/cable_modem_monitor_catalog/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solentlabs-cable-modem-monitor-catalog"
-version = "3.14.1-beta.4"
+version = "3.14.1-beta.5"
 description = "Cable Modem Monitor Catalog — modem config files and parser overrides"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "solentlabs-cable-modem-monitor-core==3.14.1-beta.4",
+    "solentlabs-cable-modem-monitor-core==3.14.1-beta.5",
 ]
 license = "MIT"
 authors = [

--- a/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb10/modem.yaml
+++ b/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb10/modem.yaml
@@ -70,6 +70,7 @@ sources:
     and 5-85 MHz and 108-684 MHz upstream'; governing spec CM-SP-PHYv4.0,
     [CableLabs DOCSIS 4.0](https://www.cablelabs.com/technologies/docsis-4-0-technology)).
     [FCC ID G95601TX](https://fccid.io/G95601TX) confirms the CGM601TCOM filing."
+  error_codewords: "[#173](https://github.com/solentlabs/cable_modem_monitor/issues/173) capture (test_data/modem.har) and modem.verified.json; the same first-column duplication on the XB6 in [Xfinity Community, April 2020](https://forums.xfinity.com/conversations/your-home-network/correctable-codewords-50-of-codewords-on-2-channels/602daed0c5375f08cdf6df9e) (index 1 equals index 33) and the XB7 in [DSLReports, November 2021](https://www.dslreports.com/forum/r33254515-Connectivity-Seeing-nearly-as-many-Correctable-as-Unerrored-Codewords-on-Ch1) (index 1 equals index 32); the page pairs Channel IDs with CMErrorCodewords counters by row index in the [RDK-B web UI template](https://github.com/rdkcentral/webui/blob/8ac407e5f75f243a8d01615d664b2e6e61522b8b/source/Styles/xb6/jst/network_setup.jst#L1073-L1107)"
 
 attribution:
   contributors:
@@ -91,9 +92,12 @@ notes: |
   Transposed table format: rows are metrics, columns are channels.
   Session cookie: DUKSID. CSRF: csrfp_token (OWASP CSRFP).
   Default IP: 10.0.0.1 (router mode).
-  Error count duplication: channel 17 (primary QAM256) reports corrected and
-  uncorrected counts identical to OFDM channel 194 — same firmware pattern as
-  XB7. Aggregate totals intentionally omitted; per-channel data is reliable.
+  Error codeword duplication: the first data column of the CM Error
+  Codewords table repeats the last column's unerrored, correctable and
+  uncorrectable counts, here QAM channel 17 and OFDM channel 194. The
+  first column is the primary channel, and its own counts never reach
+  the page, so parser.yaml skips that column and the QAM totals sum the
+  remaining QAM channels.
   OFDM downstream frequencies reported in Hz without unit suffix (e.g.,
   "774000000") rather than in MHz like QAM channels; stored as-is in Hz.
   System uptime format: "X days Xh: Xm: Xs" (spaces after colons);

--- a/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb10/parser.yaml
+++ b/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb10/parser.yaml
@@ -40,6 +40,11 @@ downstream:
         match: "CM Error Codewords"
       merge_by:
         - channel_id
+      # The first data column repeats the last column's counters in every
+      # capture, so the primary channel's own counts never appear. The
+      # evidence is in modem.yaml notes and sources.error_codewords.
+      skip_columns:
+        - 0
       rows:
         - field: channel_id
           label: "Channel ID"
@@ -150,6 +155,16 @@ system_info:
           label: "Flash Available Memory"
           type: string
 
+# QAM-only totals (PARSING_SPEC § Aggregate). The skipped first error
+# column leaves the primary channel without counters, so it is not summed.
+aggregate:
+  total_corrected:
+    sum: corrected
+    channels: downstream.qam
+  total_uncorrected:
+    sum: uncorrected
+    channels: downstream.qam
+
 computed:
   docsis_status:
     operation: combined_status
@@ -161,7 +176,3 @@ computed:
     inputs:
       total: memory_total
       free: memory_free
-# DOCSIS 3.1: aggregate intentionally omitted. Firmware duplicates OFDM
-# error data onto QAM channel IDs (channel 17 and OFDM channel 194 report
-# identical corrected/uncorrected counts — same pattern as XB7), making
-# QAM totals unreliable. Per-channel data is still available.

--- a/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb10/test_data/modem.expected.json
+++ b/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb10/test_data/modem.expected.json
@@ -4,13 +4,11 @@
       "channel_id": 17,
       "channel_number": 1,
       "channel_type": "qam",
-      "corrected": 243167206,
       "frequency": 957000000,
       "lock_status": "locked",
       "modulation": "QAM256",
       "power": -5.8,
-      "snr": 41.9,
-      "uncorrected": 357715169
+      "snr": 41.9
     },
     {
       "channel_id": 18,
@@ -135,6 +133,8 @@
     "software_image_name": "CGM601TCOM_8.5p1s3_PROD_sey",
     "software_version": "Prod_25.1_PD & SMC-BL: 7.0.0",
     "system_uptime": "4 days 16h:05m:28s",
+    "total_corrected": 2118850,
+    "total_uncorrected": 1312880,
     "upstream_channel_count": 8,
     "upstream_status": "Operational"
   },

--- a/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb6/modem.yaml
+++ b/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb6/modem.yaml
@@ -33,6 +33,7 @@ sources:
   model_aliases: "[TechInfoDepot — Technicolor CGM4140COM (XB6)](https://techinfodepot.shoutwiki.com/wiki/Technicolor_CGM4140COM)"
   auth_config: "[#111 XB6](https://github.com/solentlabs/cable_modem_monitor/issues/111)"
   chipset: "[TechInfoDepot](https://techinfodepot.shoutwiki.com/wiki/Technicolor_CGM4140COM)"
+  error_codewords: "[#111](https://github.com/solentlabs/cable_modem_monitor/issues/111) captures (test_data/modem.har and modem.verified.json); another XB6 in [Xfinity Community, April 2020](https://forums.xfinity.com/conversations/your-home-network/correctable-codewords-50-of-codewords-on-2-channels/602daed0c5375f08cdf6df9e) (index 1 equals index 33) and an XB7 in [DSLReports, November 2021](https://www.dslreports.com/forum/r33254515-Connectivity-Seeing-nearly-as-many-Correctable-as-Unerrored-Codewords-on-Ch1) (index 1 equals index 32); the page pairs Channel IDs with CMErrorCodewords counters by row index in the [RDK-B web UI template](https://github.com/rdkcentral/webui/blob/8ac407e5f75f243a8d01615d664b2e6e61522b8b/source/Styles/xb6/jst/network_setup.jst#L1073-L1107)"
 
 attribution:
   contributors:
@@ -48,6 +49,14 @@ notes: |
   Session cookie: DUKSID (vs XB7's "session"). CSRF: csrfp_token (OWASP CSRFP).
   Login form includes hidden field locale=false.
   Default IP: 10.0.0.1 (router mode).
+  Error codeword duplication: the first data column of the CM Error
+  Codewords table repeats the last column's unerrored, correctable and
+  uncorrectable counts. Which channel is last depends on the lineup: in
+  test_data/modem.har (one OFDM channel) QAM channels 1 and 41 match; in
+  test_data/modem.verified.json (two OFDM channels) QAM channel 5
+  carries OFDM channel 34's counts. The first column is the primary
+  channel, and its own counts never reach the page, so parser.yaml
+  skips that column and the QAM totals sum the remaining QAM channels.
   One third-party author email in a bundled JS library was redacted
   by hand: har-capture does not scan strings inside bundled assets.
   The private Wi-Fi network name on connection_status.jst was redacted

--- a/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb6/parser.yaml
+++ b/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb6/parser.yaml
@@ -37,6 +37,11 @@ downstream:
         type: header_text
     - merge_by:
         - channel_id
+      # The first data column repeats the last column's counters in every
+      # capture, so the primary channel's own counts never appear. The
+      # evidence is in modem.yaml notes and sources.error_codewords.
+      skip_columns:
+        - 0
       rows:
         - field: channel_id
           label: "Channel ID"
@@ -124,8 +129,8 @@ system_info:
           label: "Model"
           type: string
 
-# DOCSIS 3.1: aggregate QAM-only totals. OFDM LDPC codewords operate
-# at a vastly different scale and are not aggregated.
+# QAM-only totals (PARSING_SPEC § Aggregate). The skipped first error
+# column leaves the primary channel without counters, so it is not summed.
 aggregate:
   total_corrected:
     sum: corrected

--- a/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb6/test_data/modem.expected.json
+++ b/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb6/test_data/modem.expected.json
@@ -4,13 +4,11 @@
       "channel_id": 1,
       "channel_number": 1,
       "channel_type": "qam",
-      "corrected": 44,
       "frequency": 489000000,
       "lock_status": "locked",
       "modulation": "QAM256",
       "power": 7.1,
-      "snr": 41.0,
-      "uncorrected": 20
+      "snr": 41.0
     },
     {
       "channel_id": 2,
@@ -392,8 +390,8 @@
     "model_name": "CGM4140COM",
     "software_version": "Prod_23.2_231009 & Prod_23.2_231009",
     "system_uptime": "0 days 20h:05m:44s",
-    "total_corrected": 1675,
-    "total_uncorrected": 1095,
+    "total_corrected": 1631,
+    "total_uncorrected": 1075,
     "upstream_channel_count": 5,
     "upstream_status": "Operational"
   },

--- a/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb7/modem.yaml
+++ b/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb7/modem.yaml
@@ -32,6 +32,7 @@ sources:
   auth_config: "[#2 Technicolor XB7](https://github.com/solentlabs/cable_modem_monitor/issues/2)"
   chipset: "[WikiDevi](https://wikidevi.wi-cat.ru/Technicolor_CGM4331COM)"
   detection_hints: "[#2 Technicolor XB7](https://github.com/solentlabs/cable_modem_monitor/issues/2)"
+  error_codewords: "test_data/modem.verified.json; another XB7 in [DSLReports, November 2021](https://www.dslreports.com/forum/r33254515-Connectivity-Seeing-nearly-as-many-Correctable-as-Unerrored-Codewords-on-Ch1) (index 1 equals index 32, described there as the OFDM channel shown twice) and an XB6 in [Xfinity Community, April 2020](https://forums.xfinity.com/conversations/your-home-network/correctable-codewords-50-of-codewords-on-2-channels/602daed0c5375f08cdf6df9e) (index 1 equals index 33); the page pairs Channel IDs with CMErrorCodewords counters by row index in the [RDK-B web UI template](https://github.com/rdkcentral/webui/blob/8ac407e5f75f243a8d01615d664b2e6e61522b8b/source/Styles/xb6/jst/network_setup.jst#L1073-L1107)"
 
 attribution:
   contributors:
@@ -52,11 +53,12 @@ notes: |
   Form-based authentication to /check.jst endpoint.
   System uptime format: "X days Xh: Xm: Xs" (note spaces around colons).
   May have localized variants (Italian translations found in Rogers/Italian market).
-  Quirk — BCM3390 error count duplication: channel 17 (primary QAM256)
-  reports corrected and uncorrected counts identical to channel 34 (OFDM).
-  Confirmed per-model (observed across two independent units). Same
-  chipset-level pattern as SB8200. Aggregate intentionally omitted because
-  the duplicated OFDM data makes QAM totals unreliable.
+  Error codeword duplication: the first data column of the CM Error
+  Codewords table repeats the last column's counts. In
+  test_data/modem.verified.json that is QAM channel 17 and OFDM channel
+  34. The first column is the primary channel, and its own counts never
+  reach the page, so parser.yaml skips that column and the QAM totals
+  sum the remaining QAM channels.
   The factory Wi-Fi SSID and default password in the Device Label
   Information block on network_setup.jst were redacted by hand:
   har-capture had no labeled-credential detector at capture time.

--- a/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb7/parser.yaml
+++ b/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb7/parser.yaml
@@ -37,6 +37,11 @@ downstream:
         type: header_text
     - merge_by:
         - channel_id
+      # The first data column repeats the last column's counters in every
+      # capture, so the primary channel's own counts never appear. The
+      # evidence is in modem.yaml notes and sources.error_codewords.
+      skip_columns:
+        - 0
       rows:
         - field: channel_id
           label: "Channel ID"
@@ -118,14 +123,19 @@ system_info:
           label: "Model"
           type: string
 
+# QAM-only totals (PARSING_SPEC § Aggregate). The skipped first error
+# column leaves the primary channel without counters, so it is not summed.
+aggregate:
+  total_corrected:
+    sum: corrected
+    channels: downstream.qam
+  total_uncorrected:
+    sum: uncorrected
+    channels: downstream.qam
+
 computed:
   docsis_status:
     operation: combined_status
     inputs:
       ds: downstream_status
       us: upstream_status
-# DOCSIS 3.1: aggregate QAM-only totals. OFDM LDPC codewords operate
-# at a vastly different scale and are not aggregated.
-# Aggregate intentionally omitted. Firmware duplicates OFDM error
-# data onto QAM channel IDs (see modem.yaml quirks), making QAM
-# totals unreliable. Per-channel data is still available.

--- a/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb7/test_data/modem.expected.json
+++ b/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb7/test_data/modem.expected.json
@@ -4,13 +4,11 @@
       "channel_id": 17,
       "channel_number": 1,
       "channel_type": "qam",
-      "corrected": 1921450288,
       "frequency": 657000000,
       "lock_status": "locked",
       "modulation": "QAM256",
       "power": -3.1,
-      "snr": 37.0,
-      "uncorrected": 785
+      "snr": 37.0
     },
     {
       "channel_id": 1,
@@ -415,6 +413,8 @@
     "model_name": "CGM4331COM",
     "software_version": "Prod_24.2_PD & Prod_24.2_PD",
     "system_uptime": "13 days 03h:13m:17s",
+    "total_corrected": 956,
+    "total_uncorrected": 282,
     "upstream_channel_count": 5,
     "upstream_status": "Operational"
   },

--- a/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb8/modem.yaml
+++ b/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb8/modem.yaml
@@ -58,6 +58,7 @@ sources:
   auth_config: "[#194 XB8 error graphs](https://github.com/solentlabs/cable_modem_monitor/issues/194) HAR capture (POST /check.jst with plain username and password fields, 302 to at_a_glance.jst, DUKSID session cookie)"
   restart: '[#194 XB8 error graphs](https://github.com/solentlabs/cable_modem_monitor/issues/194) fixture HAR (GET /restore_reboot.jst, then POST /actionHandler/ajaxSet_Reset_Restore.jst carrying resetInfo and the csrfp_token cookie echoed in the body; modem answered {"reboot":true})'
   release_date: "Xfinity rollout began 2022: [DSLReports — Next Gateway XB8](https://www.dslreports.com/forum/r33227126-Next-Gateway-XB8-Technicolor-CGM4981COM-Wi-Fi-6E); [Xfinity Community Forum — NEW xFi Gateway XB8](https://forums.xfinity.com/conversations/your-home-network/new-xfi-gateway-xb8/6216d91580db9c3cdd5e96fc)"
+  error_codewords: "[#194](https://github.com/solentlabs/cable_modem_monitor/issues/194) captures (test_data/modem.har and modem.verified.json, ten days apart); the same first-column duplication on the XB6 in [Xfinity Community, April 2020](https://forums.xfinity.com/conversations/your-home-network/correctable-codewords-50-of-codewords-on-2-channels/602daed0c5375f08cdf6df9e) (index 1 equals index 33) and the XB7 in [DSLReports, November 2021](https://www.dslreports.com/forum/r33254515-Connectivity-Seeing-nearly-as-many-Correctable-as-Unerrored-Codewords-on-Ch1) (index 1 equals index 32); the page pairs Channel IDs with CMErrorCodewords counters by row index in the [RDK-B web UI template](https://github.com/rdkcentral/webui/blob/8ac407e5f75f243a8d01615d664b2e6e61522b8b/source/Styles/xb6/jst/network_setup.jst#L1073-L1107)"
 
 attribution:
   contributors:
@@ -86,16 +87,15 @@ notes: |
   Firmware renders the SC-QAM fallback "TDMA" channel type for OFDMA
   upstream channels (upstream channel 4 reports Modulation OFDMA with
   Channel Type TDMA, symbol rate 0).
-  Quirk, error count duplication, observed on XB8 as on XB7: QAM
-  channel 29 reports unerrored, correctable and uncorrectable codeword
-  counts identical to OFDM channel 34 (3309689161 correctable and
-  310472831 uncorrectable on both in the fixture). Two captures ten
-  days apart duplicate at different values, so this is firmware
-  behaviour, not a transient read.
-  Aggregate intentionally omitted for the same reason as the XB7 entry:
-  a downstream.qam sum reads 3.31 billion against a true QAM total of
-  1.57 million, so the modem exposes no error-total or error-rate
-  sensors. Per-channel error counts are unaffected.
+  Error codeword duplication: the first data column of the CM Error
+  Codewords table repeats the last column's unerrored, correctable and
+  uncorrectable counts. In the fixture that is QAM channel 29 and OFDM
+  channel 34, 3309689161 correctable and 310472831 uncorrectable on
+  both. Two captures ten days apart duplicate at different values, so
+  this is firmware behaviour, not a transient read. The first column is
+  the primary channel, and its own counts never reach the page, so
+  parser.yaml skips that column: channel 29 carries no error counts and
+  the QAM totals sum the other 29 QAM channels.
   The Logout endpoint is source_inferred: the fixture reaches
   /home_loggedout.jst as the pre-login landing page, body not captured,
   and never as the answer to a logout. Restart is HAR-observed: the fixture records the

--- a/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb8/parser.yaml
+++ b/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb8/parser.yaml
@@ -37,6 +37,11 @@ downstream:
         type: header_text
     - merge_by:
         - channel_id
+      # The first data column repeats the last column's counters in every
+      # capture, so the primary channel's own counts never appear. The
+      # evidence is in modem.yaml notes and sources.error_codewords.
+      skip_columns:
+        - 0
       rows:
         - field: channel_id
           label: "Channel ID"
@@ -118,14 +123,19 @@ system_info:
           label: "Model"
           type: string
 
+# QAM-only totals (PARSING_SPEC § Aggregate). The skipped first error
+# column leaves the primary channel without counters, so it is not summed.
+aggregate:
+  total_corrected:
+    sum: corrected
+    channels: downstream.qam
+  total_uncorrected:
+    sum: uncorrected
+    channels: downstream.qam
+
 computed:
   docsis_status:
     operation: combined_status
     inputs:
       ds: downstream_status
       us: upstream_status
-# No aggregate. Firmware duplicates OFDM channel 34's error counts onto
-# QAM channel 29 (issue #194 capture; see modem.yaml quirks), so a
-# downstream.qam sum overstates the QAM total by three orders of
-# magnitude. Per-channel error counts stay available; the modem
-# exposes no error-total or error-rate sensors.

--- a/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb8/test_data/modem.expected.json
+++ b/packages/cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb8/test_data/modem.expected.json
@@ -4,13 +4,11 @@
       "channel_id": 29,
       "channel_number": 1,
       "channel_type": "qam",
-      "corrected": 3309689161,
       "frequency": 321000000,
       "lock_status": "locked",
       "modulation": "QAM256",
       "power": 13.2,
-      "snr": 42.4,
-      "uncorrected": 310472831
+      "snr": 42.4
     },
     {
       "channel_id": 1,
@@ -391,6 +389,8 @@
     "model_name": "CGM4981COM",
     "software_version": "Prod_24.2_PD & Prod_24.2_PD",
     "system_uptime": "20 days 07h:58m:28s",
+    "total_corrected": 1567170,
+    "total_uncorrected": 228,
     "upstream_channel_count": 4,
     "upstream_status": "Operational"
   },

--- a/packages/cable_modem_monitor_catalog_tools/docs/ONBOARDING_SPEC.md
+++ b/packages/cable_modem_monitor_catalog_tools/docs/ONBOARDING_SPEC.md
@@ -1266,6 +1266,7 @@ only generate parser.py when necessary.
 | Situation | parser.yaml solution |
 |-----------|---------------------|
 | Multi-table field merging | `merge_by` on companion table |
+| Companion column the firmware fills with another column's values | `skip_columns` on companion table |
 | Different column layouts per channel type | Multiple `tables[]` entries |
 | Unit stripping | `unit` field on column/row mapping |
 | OFDM vs QAM detection | `channel_type.map` |

--- a/packages/cable_modem_monitor_core/docs/ARCHITECTURE_DECISIONS.md
+++ b/packages/cable_modem_monitor_core/docs/ARCHITECTURE_DECISIONS.md
@@ -1141,6 +1141,31 @@ lookup key — primary table wins on field conflicts.
 `resource`. Companion tables must have matching key fields for the
 merge to work.
 
+### Duplicated companion columns are declared by position
+
+**Decision:** A parser.yaml companion table declares the columns whose
+cells the firmware duplicates from another column
+(`skip_columns`, [FORMAT_TABLE_SPEC.md § Skipping duplicated columns](FORMAT_TABLE_SPEC.md#skipping-duplicated-columns-skip_columns)).
+The table contributes nothing for those columns. The modem's
+`modem.yaml` `sources:` cites the evidence.
+
+**Rationale:** On the
+[XB8](../../cable_modem_monitor_catalog/solentlabs/cable_modem_monitor_catalog/modems/technicolor/xb8/modem.yaml)
+the error-codeword table's first column repeats the last column's
+counters in every capture, so the primary channel's real counts never
+reach the page. The page pairs channel labels with counters by row
+index, so position is the only thing that identifies the bad column.
+Omitting the aggregate discarded every valid channel to exclude one
+invalid column. Matching values cannot stand in for the declaration:
+identical counter pairs occur by coincidence between healthy channels
+across the fleet at low counts.
+
+**Constrains:**
+
+- Core does not detect duplicated cells from their values.
+- `skip_columns` applies only to companion tables. It never removes a
+  channel.
+
 ---
 
 ### `parser.*` parses; `modem.yaml` owns everything else

--- a/packages/cable_modem_monitor_core/docs/FORMAT_TABLE_SPEC.md
+++ b/packages/cable_modem_monitor_core/docs/FORMAT_TABLE_SPEC.md
@@ -371,6 +371,7 @@ downstream:
 | `tables[].rows` | list | yes | Row label→field mappings |
 | `tables[].channel_type` | object | no | Channel type detection rules |
 | `tables[].merge_by` | list[string] | no | Merge into primary channels by these key fields. See [Companion Tables](#companion-tables-merge_by). |
+| `tables[].skip_columns` | list[int] | no | Data columns this companion table does not contribute. Requires `merge_by`. See [Skipping duplicated columns](#skipping-duplicated-columns-skip_columns). |
 
 Either `selector`/`rows` (flat form) or `tables` (multi-table form)
 must be present, but not both. The flat form is syntactic sugar for a
@@ -428,6 +429,35 @@ modem requires it.
 
 All current modems with companion tables use `merge_by: [channel_id]`
 because their channel IDs are unique within each companion table.
+
+### Skipping duplicated columns (skip_columns)
+
+Some firmware fills one column of a transposed companion table with
+another column's values, so that column carries no data for the channel
+it is labelled with. `skip_columns` lists those columns, and the table
+contributes nothing for them:
+
+```yaml
+    - selector:
+        type: header_text
+        match: "CM Error Codewords"
+      merge_by: [channel_id]
+      skip_columns: [0]
+      rows: ...
+```
+
+- Indexes are 0-based data columns, counted from the first cell after
+  the row label, the same convention as `columns[].index`.
+- The primary channel matching a skipped column keeps its primary-table
+  fields and receives none of the companion's, so aggregates over that
+  field skip it.
+- `merge_by` is required. In a primary table a skipped column would
+  remove a channel, which this field never does.
+- An index past the table's last column skips nothing.
+
+Columns are declared by position; Core never detects duplicated cells
+from their values. See
+[ARCHITECTURE_DECISIONS.md § Duplicated companion columns are declared by position](ARCHITECTURE_DECISIONS.md#duplicated-companion-columns-are-declared-by-position).
 
 ### Merge logic (in ModemParserCoordinator)
 

--- a/packages/cable_modem_monitor_core/docs/PARSING_SPEC.md
+++ b/packages/cable_modem_monitor_core/docs/PARSING_SPEC.md
@@ -1259,6 +1259,11 @@ filtered. The `lock_status` filter is the correct mitigation:
 unlocked channels have unreliable historical data regardless of their
 current type assignment.
 
+**Duplicated counter columns:** a companion-table column whose cells
+the firmware copies from another column is declared with
+`skip_columns`, so the channel carries no counters and sums skip it
+([FORMAT_TABLE_SPEC.md § Skipping duplicated columns](FORMAT_TABLE_SPEC.md#skipping-duplicated-columns-skip_columns)).
+
 **Execution:** The coordinator runs aggregate computation after all
 sections are extracted and parser.py hooks have run. Results are
 merged into `system_info` alongside channel counts, before the

--- a/packages/cable_modem_monitor_core/pyproject.toml
+++ b/packages/cable_modem_monitor_core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "solentlabs-cable-modem-monitor-core"
-version = "3.14.1-beta.4"
+version = "3.14.1-beta.5"
 description = "Cable Modem Monitor Core — platform-agnostic DOCSIS monitoring engine"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/models/parser_config/transposed.py
+++ b/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/models/parser_config/transposed.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import ClassVar, Literal
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, NonNegativeInt, model_validator
 
 from .common import ChannelTypeConfig, RowMapping, TableSelector
 from .format_registry import DecodeKind
@@ -23,6 +23,16 @@ class TransposedTableDefinition(BaseModel):
     rows: list[RowMapping]
     channel_type: ChannelTypeConfig | None = None
     merge_by: list[str] | None = None
+    # 0-based data columns whose cells the firmware copies from another
+    # column. FORMAT_TABLE_SPEC § Skipping duplicated columns.
+    skip_columns: list[NonNegativeInt] | None = None
+
+    @model_validator(mode="after")
+    def validate_skip_columns_companion_only(self) -> TransposedTableDefinition:
+        """Reject skip_columns on a primary table, where it would drop a channel."""
+        if self.skip_columns is not None and self.merge_by is None:
+            raise ValueError("skip_columns requires merge_by: only a companion table can skip columns")
+        return self
 
 
 class HTMLTableTransposedSection(BaseModel):

--- a/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/parsers/formats/html_table_transposed.py
+++ b/packages/cable_modem_monitor_core/solentlabs/cable_modem_monitor_core/parsers/formats/html_table_transposed.py
@@ -81,9 +81,14 @@ class HTMLTableTransposedParser(BaseParser):
         if channel_count == 0:
             return []
 
-        # Pivot: for each column index, build one channel dict.
+        # Pivot: for each column index, build one channel dict. Declared
+        # duplicate columns contribute nothing (FORMAT_TABLE_SPEC
+        # § Skipping duplicated columns).
+        skip = frozenset(self._table.skip_columns or ())
         channels: list[dict[str, Any]] = []
         for col_idx in range(channel_count):
+            if col_idx in skip:
+                continue
             channel = _extract_channel(label_map, self._table.rows, col_idx)
             if channel is None:
                 continue

--- a/packages/cable_modem_monitor_core/tests/models/fixtures/parser_config/invalid/transposed_skip_columns_negative.json
+++ b/packages/cable_modem_monitor_core/tests/models/fixtures/parser_config/invalid/transposed_skip_columns_negative.json
@@ -1,0 +1,26 @@
+{
+  "_expected_error": "greater than or equal to 0",
+  "_config": {
+    "downstream": {
+      "format": "table_transposed",
+      "resource": "/data.htm",
+      "tables": [
+        {
+          "selector": {"type": "header_text", "match": "Downstream"},
+          "rows": [
+            {"label": "Channel ID", "field": "channel_id", "type": "integer"}
+          ]
+        },
+        {
+          "selector": {"type": "header_text", "match": "Signal Stats"},
+          "merge_by": ["channel_id"],
+          "skip_columns": [-1],
+          "rows": [
+            {"label": "Channel ID", "field": "channel_id", "type": "integer"},
+            {"label": "Total Correctable Codewords", "field": "corrected", "type": "integer"}
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/packages/cable_modem_monitor_core/tests/models/fixtures/parser_config/invalid/transposed_skip_columns_without_merge_by.json
+++ b/packages/cable_modem_monitor_core/tests/models/fixtures/parser_config/invalid/transposed_skip_columns_without_merge_by.json
@@ -1,0 +1,18 @@
+{
+  "_expected_error": "skip_columns requires merge_by",
+  "_config": {
+    "downstream": {
+      "format": "table_transposed",
+      "resource": "/data.htm",
+      "tables": [
+        {
+          "selector": {"type": "header_text", "match": "Downstream"},
+          "skip_columns": [0],
+          "rows": [
+            {"label": "Channel ID", "field": "channel_id", "type": "integer"}
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/packages/cable_modem_monitor_core/tests/models/fixtures/parser_config/valid/transposed_skip_columns.json
+++ b/packages/cable_modem_monitor_core/tests/models/fixtures/parser_config/valid/transposed_skip_columns.json
@@ -1,0 +1,25 @@
+{
+  "downstream": {
+    "format": "table_transposed",
+    "resource": "/data.htm",
+    "tables": [
+      {
+        "selector": {"type": "header_text", "match": "Downstream"},
+        "rows": [
+          {"label": "Channel ID", "field": "channel_id", "type": "integer"},
+          {"label": "Frequency", "field": "frequency", "type": "frequency"}
+        ],
+        "channel_type": {"fixed": "qam"}
+      },
+      {
+        "selector": {"type": "header_text", "match": "Signal Stats"},
+        "merge_by": ["channel_id"],
+        "skip_columns": [0],
+        "rows": [
+          {"label": "Channel ID", "field": "channel_id", "type": "integer"},
+          {"label": "Total Correctable Codewords", "field": "corrected", "type": "integer"}
+        ]
+      }
+    ]
+  }
+}

--- a/packages/cable_modem_monitor_core/tests/parsers/fixtures/coordinator/valid/transposed_merge_by_skip_columns.json
+++ b/packages/cable_modem_monitor_core/tests/parsers/fixtures/coordinator/valid/transposed_merge_by_skip_columns.json
@@ -1,0 +1,50 @@
+{
+  "_description": "Companion column declared in skip_columns contributes nothing; its channel keeps primary fields and the aggregate skips it",
+  "_html": {
+    "/status.html": "<html><body><table><tr><th>Downstream</th><th colspan=3>Value</th></tr><tr><td>Channel ID</td><td>10</td><td>9</td><td>8</td></tr><tr><td>Power Level</td><td>5 dBmV</td><td>4 dBmV</td><td>3 dBmV</td></tr></table><table><tr><th>Signal Stats (Codewords)</th><th colspan=3>Value</th></tr><tr><td>Channel ID</td><td>10</td><td>9</td><td>8</td></tr><tr><td>Total Correctable Codewords</td><td>921</td><td>609</td><td>921</td></tr><tr><td>Total Uncorrectable Codewords</td><td>5</td><td>0</td><td>5</td></tr></table></body></html>"
+  },
+  "_parser_config": {
+    "downstream": {
+      "format": "table_transposed",
+      "resource": "/status.html",
+      "tables": [
+        {
+          "selector": {"type": "header_text", "match": "Downstream"},
+          "rows": [
+            {"label": "Channel ID", "field": "channel_id", "type": "integer"},
+            {"label": "Power Level", "field": "power", "type": "float", "unit": "dBmV"}
+          ],
+          "channel_type": {"fixed": "qam"}
+        },
+        {
+          "selector": {"type": "header_text", "match": "Signal Stats (Codewords)"},
+          "merge_by": ["channel_id"],
+          "skip_columns": [0],
+          "rows": [
+            {"label": "Channel ID", "field": "channel_id", "type": "integer"},
+            {"label": "Total Correctable Codewords", "field": "corrected", "type": "integer"},
+            {"label": "Total Uncorrectable Codewords", "field": "uncorrected", "type": "integer"}
+          ]
+        }
+      ]
+    },
+    "aggregate": {
+      "total_corrected": {"sum": "corrected", "channels": "downstream.qam"},
+      "total_uncorrected": {"sum": "uncorrected", "channels": "downstream.qam"}
+    }
+  },
+  "_expected": {
+    "downstream": [
+      {"channel_id": 10, "channel_number": 1, "power": 5.0, "channel_type": "qam"},
+      {"channel_id": 9, "channel_number": 2, "power": 4.0, "channel_type": "qam", "corrected": 609, "uncorrected": 0},
+      {"channel_id": 8, "channel_number": 3, "power": 3.0, "channel_type": "qam", "corrected": 921, "uncorrected": 5}
+    ],
+    "upstream": [],
+    "system_info": {
+      "downstream_channel_count": 3,
+      "upstream_channel_count": 0,
+      "total_corrected": 1530,
+      "total_uncorrected": 5
+    }
+  }
+}

--- a/packages/cable_modem_monitor_core/tests/parsers/fixtures/html_table_transposed/valid/skip_columns.json
+++ b/packages/cable_modem_monitor_core/tests/parsers/fixtures/html_table_transposed/valid/skip_columns.json
@@ -1,0 +1,18 @@
+{
+  "_description": "Companion table skips declared data columns; an index past the last column skips nothing",
+  "_html": "<html><body><table><tr><th>Signal Stats</th><th colspan=3>Value</th></tr><tr><td>Channel ID</td><td>10</td><td>9</td><td>11</td></tr><tr><td>Total Correctable Codewords</td><td>900</td><td>12</td><td>900</td></tr></table></body></html>",
+  "_resource": "/status.html",
+  "_config": {
+    "selector": {"type": "header_text", "match": "Signal Stats"},
+    "merge_by": ["channel_id"],
+    "skip_columns": [0, 7],
+    "rows": [
+      {"label": "Channel ID", "field": "channel_id", "type": "integer"},
+      {"label": "Total Correctable Codewords", "field": "corrected", "type": "integer"}
+    ]
+  },
+  "_expected": [
+    {"channel_id": 9, "corrected": 12},
+    {"channel_id": 11, "corrected": 900}
+  ]
+}

--- a/tests/components/test_version_and_startup.py
+++ b/tests/components/test_version_and_startup.py
@@ -22,7 +22,7 @@ class TestVersion:
         Use: python scripts/release.py <version>
         The script updates const.py, manifest.json, and this file.
         """
-        assert VERSION == "3.14.1-beta.4"
+        assert VERSION == "3.14.1-beta.5"
 
     def test_startup_log_message_format(self):
         """The startup log line includes the version string."""


### PR DESCRIPTION
## What's in it

**Error totals and error rates on the Technicolor XB7, XB8 and XB10.** In
every capture on file from the XB6, XB7, XB8 and XB10, the first column of the
error codeword table repeats the last column's counts, so the primary
channel's own counts never appear. These entries used to publish no totals at
all to avoid summing the copy. Now only that column is skipped, and the totals
and rates sum every other QAM channel. Thanks to @Boby360 for the captures.

**The Technicolor XB6 error total no longer counts another channel's
codewords.** The same duplicated column was summed into the XB6's QAM totals;
with two OFDM channels it carried the OFDM channel's counts and put the total
in the billions. It is now skipped like on the other XB gateways.

**`skip_columns` for transposed companion tables.** A parser can declare the
data columns whose cells the firmware copies from another column. It applies
to companion tables only and never removes a channel. See
`FORMAT_TABLE_SPEC.md`.

## Upgrade notes

On XB gateways the primary downstream channel's Corrected and Uncorrected
sensors now read unknown, because the value they showed belonged to another
channel. On the XB6 the totals drop to the real QAM figure on the first poll,
which Home Assistant records as a counter reset. XB7, XB8 and XB10 installs
gain the total and rate sensors; run `generate_dashboard` again for the error
graphs.

## Verification

- `make validate-ci` green (run by `release.py`): Core 2337, catalog 517
  (88 skipped), HA 1142 passed.
- Goldens for the four XB entries differ only in the first channel losing its
  two counters and in the totals.
- Hand-tested in a local HA container against the XB8 capture served by the
  mock server: totals 1,567,170 / 228, channel 29's error sensors unknown.

Related to #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)
